### PR TITLE
feat:  Complete missing functionalities in workflows

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,14 +7,20 @@ on:
 jobs:
   review_pr_title:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
       - name: Check PR title format
         id: check_title
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           if [[ ! "$TITLE" =~ ^(feat|fix|docs|chore|perf|test|refactor): ]]; then
             echo "::error::PR title does not follow the convention 'type: description'. Please review the title."
+            gh pr review ${{ github.event.pull_request.number }} -r -b "This PR does not satisfies PR title format. Title format should be same as one of the conventional commits"
             exit 1
           else
             echo "PR title meets the required format."
           fi
+            

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -41,4 +41,19 @@ jobs:
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}        
+          token: ${{ secrets.CODECOV_TOKEN }}      
+
+  on_failure:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    if: ${{ failure() }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: review_pr
+        id: review-pr
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} -r -b "Tests are failed. Please review the PR."
+          exit 1

--- a/.github/workflows/pr-label-assign.yml
+++ b/.github/workflows/pr-label-assign.yml
@@ -1,0 +1,31 @@
+# This wrokflow is triggered when a PR is labeled. 
+# It assigns reviewers based on the label applied to the PR.
+
+name: PR Label Assigner
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    
+    - name: Check out the repository
+      uses: actions/checkout@v4
+        
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install PyYAML
+      run: pip install pyyaml
+
+    - name: Assign Reviewers # Assign responsible people based on labels
+      run: |
+        python .github/scripts/assign_reviewers.py "${{ github.event.pull_request.number }}" "${{ github.event.label.name }}"


### PR DESCRIPTION
## Description

Three main functionalities were missing in workflows:
- In current main, When PR is opened, actions bot assigns a label based on the changed directories. And based on these labels,  actions bot assign devs. However, when someone adding a label manually, It does not assign anybody. 
- When a PR is opened with a non-conventional title, an action runs and fails. However, it should also request a change from the contributor. 
- a GitHub Action bot should also request a change if tests fail

## What is Changed


- When PR Is opened, If one of the labels are applied, Now bot assigns corresponding contributors
- If PR title does not meet the required format, Now a bot requests a change
- If tests fail, now bot will request a change


## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).