### PR TITLE
fix: Fix ambiguous behavior of `extend` while adding a submodel 

### DIFF
--- a/mithril/framework/logical/model.py
+++ b/mithril/framework/logical/model.py
@@ -1208,11 +1208,10 @@ class Model(BaseModel):
         if self.is_frozen:
             raise AttributeError("Model is frozen and can not be extended!")
 
-        model, kwargs = (
-            (info._model, info._connections)
-            if isinstance(info, ExtendInfo)
-            else (info, {})
-        )
+        # Call model with empty arguments if directly model is given.
+        if isinstance(info, PrimitiveModel | Model):
+            info = info()
+        model, kwargs = info._model, info._connections
 
         if not isinstance(model, BaseModel | PrimitiveModel):
             raise TypeError("Added element should be a Model type.")

--- a/tests/scripts/test_codegen.py
+++ b/tests/scripts/test_codegen.py
@@ -291,7 +291,7 @@ def test_variadic_input_primitive_2(file_path: str):
 @with_temp_file(".py")
 def test_default_kwarg_reduction_1(file_path: str):
     model = Model()
-    model += Mean()()
+    model += Mean()
 
     backend = NumpyBackend()
     mithril.compile(model, backend, inference=False, jit=False, file_path=file_path)

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -7176,6 +7176,6 @@ def test_empty_call_vs_direct_model_extending():
     model1 += LeakyRelu()
 
     model2 = Model()
-    model2 += LeakyRelu()
+    model2 += LeakyRelu()()
 
     assert_models_equal(model1, model2)

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -107,6 +107,7 @@ from mithril.models import (
 )
 from mithril.utils.type_utils import is_list_int
 
+from .helper import assert_models_equal
 from .test_shapes import check_shapes_semantically
 from .test_utils import (
     assert_connections,
@@ -1502,8 +1503,8 @@ def test_cyclic_extension():
 
 def test_canonic_example():
     model = Model()
-    model += LeakyRelu()()
-    model += LeakyRelu()()
+    model += LeakyRelu()
+    model += LeakyRelu()
     comp_model = compile(model=model, backend=NumpyBackend())
     assert set(comp_model._input_keys) == {"input", "_input_0"}
     assert set(comp_model.output_keys) == {"output"}
@@ -6819,7 +6820,7 @@ def test_iadd_1():
 def test_iadd_2():
     model = Model()
     model += MatrixMultiply()(right="w1")
-    model += Relu()()
+    model += Relu()
     model += Sigmoid()
     model += MatrixMultiply()(left=model.canonical_output, right="w4")
 
@@ -7168,3 +7169,13 @@ def test_string_iokey_value_2():
     outputs = pm.evaluate(trainable_keys)
     ref_outputs = {"output": backend.ones(7) * 6}
     assert_results_equal(outputs, ref_outputs)
+
+
+def test_empty_call_vs_direct_model_extending():
+    model1 = Model()
+    model1 += LeakyRelu()
+
+    model2 = Model()
+    model2 += LeakyRelu()
+
+    assert_models_equal(model1, model2)

--- a/tests/scripts/test_summary.py
+++ b/tests/scripts/test_summary.py
@@ -22,6 +22,7 @@ import pytest
 import mithril
 from mithril import JaxBackend, NumpyBackend, TorchBackend
 from mithril.framework.common import (
+    NOT_GIVEN,
     Connect,
     Connection,
     IOKey,
@@ -862,9 +863,9 @@ def test_table_5():
 def test_physical_summary_1():
     model = Model()
     model += Linear(dimension=5)(input="input")
-    model += LeakyRelu()()
+    model += LeakyRelu()
     model += (lin1 := Linear(dimension=3))
-    model += (l_relu := LeakyRelu())
+    model += (l_relu := LeakyRelu())(slope=NOT_GIVEN)
     l_relu.set_values({"slope": 1e-1})
     model += Relu()
     lin1.set_shapes({"input": [3, 5]})
@@ -887,7 +888,7 @@ def test_physical_summary_2():
     model1 += Sigmoid()
     model = Model()
     model += Linear(dimension=5)(input="input")
-    model += LeakyRelu()()
+    model += LeakyRelu()
     model += Linear(dimension=3)
     model += model1
     assert isinstance(model.canonical_input, Connection)
@@ -1290,7 +1291,7 @@ def test_logical_model_summary_2():
     model += Convolution2D(kernel_size=4, out_channels=4)
     model += Relu()
     model += Convolution2D(kernel_size=4, out_channels=4)
-    model += LeakyRelu()()
+    model += LeakyRelu()
     model += Flatten(start_dim=1)
     model += Linear(dimension=1)
     model += Sum()


### PR DESCRIPTION
Closes #20

## Description

Bug of `extend` fixed.

## What is Changed

Ambiguity of model extension without calling submodel and calling submodel with no arguments bug fixed by calling submodel with no arguments in the beginning of extend if directly model is given.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).