### PR TITLE
feat: Split primitive usable like extend template

### DIFF
--- a/mithril/backends/with_autograd/jax_backend/ops.py
+++ b/mithril/backends/with_autograd/jax_backend/ops.py
@@ -213,6 +213,7 @@ __all__ = [
     "reduce_argmax",
     "unique",
     "trapezoid",
+    "split",
 ]
 
 

--- a/mithril/backends/with_autograd/mlx_backend/ops.py
+++ b/mithril/backends/with_autograd/mlx_backend/ops.py
@@ -184,6 +184,7 @@ __all__ = [
     "common_primitive_func_dict",
     "reduce_argmin",
     "reduce_argmax",
+    "split",
 ]
 
 

--- a/mithril/backends/with_autograd/torch_backend/ops.py
+++ b/mithril/backends/with_autograd/torch_backend/ops.py
@@ -205,6 +205,7 @@ __all__ = [
     "astype",
     "unique",
     "trapezoid",
+    "split",
 ]
 
 

--- a/mithril/backends/with_manualgrad/numpy_backend/ops.py
+++ b/mithril/backends/with_manualgrad/numpy_backend/ops.py
@@ -206,6 +206,7 @@ __all__ = [
     "reduce_argmax",
     "unique",
     "trapezoid",
+    "split",
 ]
 
 

--- a/mithril/framework/common.py
+++ b/mithril/framework/common.py
@@ -1073,6 +1073,9 @@ class TemplateBase:
     def transpose(self, axes: tuple[int, ...] | TemplateBase | None = None):
         return ExtendTemplate(connections=[self, axes], model="transpose")
 
+    def split(self, split_size: int, axis: int):
+        return ExtendTemplate(connections=[self, split_size, axis], model="split")
+
 
 class ExtendTemplate(TemplateBase):
     output_connection: ConnectionData | None

--- a/mithril/framework/logical/essential_primitives.py
+++ b/mithril/framework/logical/essential_primitives.py
@@ -102,6 +102,7 @@ __all__ = [
     "Cast",
     "Transpose",
     "Sqrt",
+    "Split",
 ]
 ConstantType = float | int | Constant
 
@@ -1188,3 +1189,30 @@ class Transpose(PrimitiveModel):
         output: ConnectionType = NOT_GIVEN,
     ) -> ExtendInfo:
         return super().__call__(input=input, axes=axes, output=output)
+
+
+class Split(PrimitiveModel):
+    split_size: Connection
+    axis: Connection
+    input: Connection
+    output: Connection
+
+    def __init__(self, split_size: int | tuple[int], axis: int = 0):
+        super().__init__(
+            formula_key="split",
+            output=TensorType([("Var2", ...)]),
+            input=TensorType([("Var1", ...)]),
+            split_size=Scalar(int | tuple[int], split_size),
+            axis=Scalar(int, axis),
+        )
+
+    def __call__(  # type: ignore[override]
+        self,
+        input: ConnectionType = NOT_GIVEN,
+        split_size: ConnectionType = NOT_GIVEN,
+        axis: ConnectionType = NOT_GIVEN,
+        output: ConnectionType = NOT_GIVEN,
+    ) -> ExtendInfo:
+        return super().__call__(
+            input=input, split_size=split_size, axis=axis, output=output
+        )

--- a/mithril/framework/logical/model.py
+++ b/mithril/framework/logical/model.py
@@ -76,6 +76,7 @@ from .essential_primitives import (
     ShiftLeft,
     ShiftRight,
     Size,
+    Split,
     Sqrt,
     Subtract,
     Sum,
@@ -128,6 +129,7 @@ ops_table: dict[str, type[PrimitiveModel]] = {
     "rshift": ShiftRight,
     "minus": Minus,
     "transpose": Transpose,
+    "split": Split,
 }
 
 

--- a/mithril/models/primitives.py
+++ b/mithril/models/primitives.py
@@ -1893,33 +1893,6 @@ class NanToNum(PrimitiveModel):
         )
 
 
-class Split(PrimitiveModel):
-    split_size: Connection
-    dim: Connection
-    input: Connection
-    output: Connection
-
-    def __init__(self, split_size: int | tuple[int], dim: int = 0):
-        super().__init__(
-            formula_key="split",
-            output=TensorType([("Var2", ...)]),
-            input=TensorType([("Var1", ...)]),
-            split_size=Scalar(int | tuple[int], split_size),
-            dim=Scalar(int, dim),
-        )
-
-    def __call__(  # type: ignore[override]
-        self,
-        input: ConnectionType = NOT_GIVEN,
-        split_size: ConnectionType = NOT_GIVEN,
-        dim: ConnectionType = NOT_GIVEN,
-        output: ConnectionType = NOT_GIVEN,
-    ) -> ExtendInfo:
-        return super().__call__(
-            input=input, split_size=split_size, dim=dim, output=output
-        )
-
-
 class Pad(PrimitiveModel):
     input: Connection
     pad: Connection


### PR DESCRIPTION
## Description

Make split primitive usable as extend template. Closes #33 

## What is Changed

- Exposed split primitive.
- Split primitive now usable like extend template.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).