### PR TITLE
fix: Tensor slicing does not work with ellipsis

### DIFF
--- a/mithril/framework/logical/model.py
+++ b/mithril/framework/logical/model.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from types import UnionType
+from types import EllipsisType, UnionType
 from typing import Self, TypeVar, overload
 
 from ...utils.utils import OrderedSet, find_dominant_type
@@ -970,7 +970,7 @@ class Model(BaseModel):
                 result = conv_model.conns.get_connection("output")
                 assert result is not None
                 update_canonical_input = True
-            elif dominant_type not in [float, int, bool, slice]:
+            elif dominant_type not in [float, int, bool, slice, EllipsisType]:
                 raise TypeError(
                     f"{dominant_type} type is not supported for conversion in "
                     "a container!"

--- a/tests/scripts/test_extend_template.py
+++ b/tests/scripts/test_extend_template.py
@@ -1455,6 +1455,36 @@ def test_tensoritem_multiple_slice_3():
     assert outputs["output"].shape == (1, 6)
 
 
+def test_tensor_item_with_ellipsis_at_beginning():
+    input = IOKey("input", shape=(3, 4, 5))
+    model = Model()
+    model += Buffer()(input=input[..., 3], output="output")
+
+    backend = JaxBackend()
+    data = {"input": backend.randn(3, 4, 5)}
+
+    pm = mithril.compile(model, backend=backend)
+    output = pm.evaluate(data)["output"]
+
+    assert output.shape == (3, 4)
+    np.testing.assert_allclose(output, data["input"][..., 3])
+
+
+def test_tensor_item_with_ellipsis_in_middle():
+    input = IOKey("input", shape=(2, 3, 4, 5, 6))
+    model = Model()
+    model += Buffer()(input=input[0, ..., 3], output="output")
+
+    backend = JaxBackend()
+    data = {"input": backend.randn(2, 3, 4, 5, 6)}
+
+    pm = mithril.compile(model, backend=backend)
+    output = pm.evaluate(data)["output"]
+
+    assert output.shape == (3, 4, 5)
+    np.testing.assert_allclose(output, data["input"][0, ..., 3])
+
+
 def test_tranpose_1():
     backend = JaxBackend()
     model = Model()


### PR DESCRIPTION
## Description

Closes #38 

## What is Changed

- Scalar now can take EllipsisType as value.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).