### PR TITLE
feat: Unify key definitions with IOKey in initialization of all primitive models

### DIFF
--- a/mithril/framework/common.py
+++ b/mithril/framework/common.py
@@ -215,7 +215,10 @@ MainValueInstance = (
 )
 
 _TensorTypes = int | float | bool
-TensorValueType = _TensorTypes | tuple["TensorValueType", ...] | list["TensorValueType"]
+_TensorValueType = (
+    _TensorTypes | tuple["_TensorValueType", ...] | list["_TensorValueType"]
+)
+TensorValueType = _TensorValueType | Constant
 
 LossKey = "loss"
 FinalCost = "final_cost"
@@ -781,9 +784,6 @@ class Scalar(BaseData):
         possible_types: ScalarType | type[str] | UnionType = MainValueInstance | str,
         value: MainValueType | ToBeDetermined | str = TBD,
     ) -> None:
-        if possible_types is None and not isinstance(value, ToBeDetermined):
-            possible_types = self.find_type(value)
-
         super().__init__(type=possible_types)
         # Update type if any value is given.
         # TODO: Check why str is excluded.
@@ -844,7 +844,7 @@ class Scalar(BaseData):
 
 
 # TODO: Should we include Constant type here in TypeVarTensorType?
-TypeVarTensorType = TypeVar("TypeVarTensorType", int, float, bool, int | float | bool)
+TypeVarTensorType = TypeVar("TypeVarTensorType", int, float, bool)
 
 
 # TODO: Convert MyTensor to Tensor when Tensor and Scalar is removed

--- a/mithril/framework/common.py
+++ b/mithril/framework/common.py
@@ -21,7 +21,7 @@ from enum import Enum
 from functools import partial, reduce
 from itertools import combinations, cycle, product, zip_longest
 from types import EllipsisType, GenericAlias, UnionType
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, TypeVar, get_args, get_origin, overload
 
 from ..backends.backend import Backend
 from ..core import (
@@ -59,7 +59,6 @@ __all__ = [
     "ShapeRepr",
     "Constraint",
     "create_shape_map",
-    "TensorType",
     "Tensor",
     "Scalar",
     "ShapesType",
@@ -191,6 +190,7 @@ MainValueType = (
     | tuple[Any, ...]
     | list[Any]
     | dict[Any, Any]
+    | bool
     | None
     | EllipsisType
     | PaddingType
@@ -205,6 +205,7 @@ MainValueInstance = (
     | tuple  # type: ignore
     | list  # type: ignore
     | dict  # type: ignore
+    | bool
     | None
     | EllipsisType
     | PaddingType
@@ -213,10 +214,8 @@ MainValueInstance = (
     | Dtype
 )
 
-
-_TensorTypes = int | float | Constant | tuple
+_TensorTypes = int | float | bool
 TensorValueType = _TensorTypes | tuple["TensorValueType", ...] | list["TensorValueType"]
-
 
 LossKey = "loss"
 FinalCost = "final_cost"
@@ -779,14 +778,11 @@ class Scalar(BaseData):
 
     def __init__(
         self,
-        possible_types: ScalarType | UnionType | None = None,
+        possible_types: ScalarType | type[str] | UnionType = MainValueInstance | str,
         value: MainValueType | ToBeDetermined | str = TBD,
     ) -> None:
-        if possible_types is None:
-            if isinstance(value, ToBeDetermined):
-                raise Exception("No possible types or value is given!")
-            else:
-                possible_types = self.find_type(value)
+        if possible_types is None and not isinstance(value, ToBeDetermined):
+            possible_types = self.find_type(value)
 
         super().__init__(type=possible_types)
         # Update type if any value is given.
@@ -847,28 +843,31 @@ class Scalar(BaseData):
         return updates
 
 
-class TensorType:
-    def __init__(
-        self,
-        shape_template: ShapeTemplateType,
-        possible_types: type | UnionType = float | int | bool,
-        value: TensorValueType | ToBeDetermined = TBD,
-        interval: list[float | int] | None = None,
-    ) -> None:
-        self._type = possible_types
-        self.shape_template = shape_template
-        self.value = value
-        if interval is None:
-            interval = []
-        self.interval = interval
+# TODO: Should we include Constant type here in TypeVarTensorType?
+TypeVarTensorType = TypeVar("TypeVarTensorType", int, float, bool, int | float | bool)
 
-    def construct(self, shape_node: ShapeNode) -> Tensor[Any]:
-        return Tensor(
-            shape=shape_node,
-            possible_types=self._type,
-            value=self.value,
-            interval=self.interval,
-        )
+
+# TODO: Convert MyTensor to Tensor when Tensor and Scalar is removed
+class MyTensor(Generic[TypeVarTensorType]):
+    def __init__(self, value: TensorValueType):
+        self.value: TensorValueType = value
+
+    # @staticmethod
+    # def is_tensor_type(t: Any) -> TypeGuard[TypeVarTensorType]:
+    #     return isinstance(t, (int, float, bool))
+
+
+# Check if a type is a specialization of MyTensor
+def is_mytensor_type(type_obj) -> bool:
+    return get_origin(type_obj) is MyTensor
+
+
+# Check if a type is a specialization of MyTensor
+def get_mytensor_subtype(type_obj: MyTensor) -> type:
+    return get_args(type_obj)[0]
+
+
+GenericTensorType = MyTensor[int] | MyTensor[bool] | MyTensor[float]
 
 
 @dataclass
@@ -1131,10 +1130,11 @@ class IOKey(TemplateBase):
     def __init__(
         self,
         name: str | None = None,
-        value: MainValueType | ToBeDetermined | str = TBD,
+        value: TensorValueType | MainValueType | ToBeDetermined | str = TBD,
         shape: ShapeTemplateType | None = None,
-        type: UnionType | type | None = None,
+        type: NestedListType | UnionType | type | None = None,
         expose: bool = True,
+        interval: list[float | int] | None = None,
     ) -> None:
         super().__init__()
         self._name = name
@@ -1142,6 +1142,7 @@ class IOKey(TemplateBase):
         self._shape = shape
         self._type = type
         self._expose = expose
+        self._interval = interval
 
         # TODO: Shape should not be [] also!
         if self._value is not TBD and self._shape is not None and self._shape != []:
@@ -1152,7 +1153,7 @@ class IOKey(TemplateBase):
 
         if self._value is not TBD and self._type is not None:
             value_type = find_type(self._value)
-            if value_type != self._type:
+            if find_intersection_type(value_type, self._type) is None:
                 raise TypeError(
                     f"type of the given value and given type does not match. Given "
                     f"type is {self._type} while type of value is {value_type}"

--- a/mithril/framework/logical/base.py
+++ b/mithril/framework/logical/base.py
@@ -39,6 +39,7 @@ from ..common import (
     IOKey,
     MainValueInstance,
     MainValueType,
+    NestedListType,
     NotAvailable,
     Scalar,
     ShapeNode,
@@ -395,11 +396,11 @@ class BaseModel(abc.ABC):
 
     def set_types(
         self,
-        config: Mapping[str | Connection, type | UnionType]
-        | Mapping[Connection, type | UnionType]
-        | Mapping[str, type | UnionType]
+        config: Mapping[str | Connection, type | UnionType | NestedListType]
+        | Mapping[Connection, type | UnionType | NestedListType]
+        | Mapping[str, type | UnionType | NestedListType]
         | None = None,
-        **kwargs: type | UnionType,
+        **kwargs: type | UnionType | NestedListType,
     ):
         """
         Set types of any connection in the Model

--- a/mithril/framework/logical/essential_primitives.py
+++ b/mithril/framework/logical/essential_primitives.py
@@ -22,9 +22,10 @@ from ..common import (
     TBD,
     Connection,
     ConnectionType,
-    Scalar,
+    GenericTensorType,
+    IOKey,
+    MyTensor,
     ShapeTemplateType,
-    TensorType,
     TensorValueType,
     ToBeDetermined,
 )
@@ -118,8 +119,8 @@ class Buffer(PrimitiveModel):
         super().__init__(
             formula_key="buffer",
             name=name,
-            output=TensorType([("Var", ...)]),
-            input=TensorType([("Var", ...)]),
+            output=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
 
@@ -144,10 +145,10 @@ class ToTuple(PrimitiveModel):
     ) -> None:
         self.factory_args = {"n": n}
         key_definitions = {
-            "output": Scalar(tuple[int | float | bool | list | tuple, ...])
+            "output": IOKey(type=tuple[int | float | bool | list | tuple, ...])
         }
         key_definitions |= {
-            f"input{idx+1}": Scalar(int | float | bool | list | tuple)
+            f"input{idx+1}": IOKey(type=int | float | bool | list | tuple)
             for idx in range(n)
         }
         self.factory_inputs = kwargs  # type: ignore
@@ -168,9 +169,9 @@ class ArithmeticOperation(PrimitiveModel):
         super().__init__(
             formula_key=formula_key,
             name=name,
-            output=TensorType([("Var_out", ...)]),
-            left=TensorType([("Var_1", ...)]),
-            right=TensorType([("Var_2", ...)]),
+            output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+            left=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+            right=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
         )
 
         self._set_constraint(
@@ -211,18 +212,18 @@ class Power(PrimitiveModel):
             super().__init__(
                 formula_key="robust_power",
                 name=name,
-                output=TensorType([("Var_out", ...)]),
-                base=TensorType([("Var_1", ...)]),
-                exponent=TensorType([("Var_2", ...)]),
-                threshold=TensorType([], ConstantType),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                base=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                exponent=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
+                threshold=IOKey(shape=[], type=GenericTensorType),
             )
             self.threshold.set_differentiable(False)  # type: ignore
         else:
             super().__init__(
                 formula_key="power",
-                output=TensorType([("Var_out", ...)]),
-                base=TensorType([("Var_1", ...)]),
-                exponent=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                base=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                exponent=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
 
         self._set_constraint(
@@ -245,7 +246,7 @@ class Power(PrimitiveModel):
         is_constant = isinstance(threshold, Constant)
         if self.robust:
             kwargs["threshold"] = threshold
-        elif not (is_constant and threshold is Constant.MIN_POSITIVE_NORMAL):
+        elif not (is_constant and threshold == Constant.MIN_POSITIVE_NORMAL):
             raise ValueError("Threshold cannot be specified when robust mode is off")
 
         return super().__call__(**kwargs)
@@ -298,9 +299,9 @@ class Divide(PrimitiveModel):
         super().__init__(
             formula_key="divide",
             name=name,
-            output=TensorType([("Var_out", ...)], float),
-            numerator=TensorType([("Var_1", ...)]),
-            denominator=TensorType([("Var_2", ...)]),
+            output=IOKey(shape=[("Var_out", ...)], type=MyTensor[float]),
+            numerator=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+            denominator=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"numerator": numerator, "denominator": denominator}
         self._set_constraint(
@@ -334,9 +335,9 @@ class FloorDivide(PrimitiveModel):
         super().__init__(
             formula_key="floor_divide",
             name=name,
-            output=TensorType([("Var_out", ...)]),
-            numerator=TensorType([("Var_1", ...)]),
-            denominator=TensorType([("Var_2", ...)]),
+            output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+            numerator=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+            denominator=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"numerator": numerator, "denominator": denominator}
 
@@ -373,9 +374,9 @@ class MatrixMultiply(PrimitiveModel):
         super().__init__(
             formula_key="matrix_multiplication",
             name=name,
-            output=TensorType([("Var3", ...), "x", "z"]),
-            left=TensorType([("Var1", ...), "x", "y"]),
-            right=TensorType([("Var2", ...), "y", "z"]),
+            output=IOKey(shape=[("Var3", ...), "x", "z"], type=GenericTensorType),
+            left=IOKey(shape=[("Var1", ...), "x", "y"], type=GenericTensorType),
+            right=IOKey(shape=[("Var2", ...), "y", "z"], type=GenericTensorType),
         )
         self.factory_inputs = {"left": left, "right": right}
         self._set_constraint(
@@ -405,8 +406,8 @@ class Shape(PrimitiveModel):
         super().__init__(
             formula_key="shape",
             name=name,
-            output=Scalar(tuple[int, ...]),
-            input=TensorType([("input", ...)]),
+            output=IOKey(shape=[], type=tuple[int, ...]),
+            input=IOKey(shape=[("input", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
         self._set_constraint(fn=shape_constraints, keys=["output", "input"])
@@ -437,9 +438,9 @@ class Reshape(PrimitiveModel):
         super().__init__(
             formula_key="reshape",
             name=name,
-            output=TensorType(output_shape_map),
-            input=TensorType([("input", ...)]),
-            shape=Scalar(tuple[int | None, ...] | list[int | None], shape),
+            output=IOKey(shape=output_shape_map, type=GenericTensorType),
+            input=IOKey(shape=[("input", ...)], type=GenericTensorType),
+            shape=IOKey(type=tuple[int | None, ...] | list[int | None], value=shape),
         )
         # TODO: currently putting shape to factory_inputs raises an error,
         # add shape to factory_inputs when the issue is resolved
@@ -465,8 +466,8 @@ class Length(PrimitiveModel):
         super().__init__(
             formula_key="length",
             name=name,
-            output=Scalar(int),
-            input=TensorType([("Var", ...)]),
+            output=IOKey(type=int),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
 
@@ -487,9 +488,9 @@ class Cast(PrimitiveModel):
         super().__init__(
             formula_key="astype",
             name=name,
-            output=TensorType([("Var", ...)]),
-            input=TensorType([("Var", ...)]),
-            dtype=Scalar(Dtype, dtype),
+            output=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            dtype=IOKey(type=Dtype),
         )
         self.factory_inputs = {"dtype": dtype}
 
@@ -512,8 +513,8 @@ class DType(PrimitiveModel):
         super().__init__(
             formula_key="dtype",
             name=name,
-            output=Scalar(core.Dtype),
-            input=TensorType([("Var", ...)]),
+            output=IOKey(type=core.Dtype),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
 
@@ -538,9 +539,9 @@ class Size(PrimitiveModel):
         super().__init__(
             formula_key="size",
             name=name,
-            output=Scalar(int | tuple[int, ...]),
-            input=TensorType([("Var", ...)]),
-            dim=Scalar(int | tuple[int, ...] | None, dim),
+            output=IOKey(type=int | tuple[int, ...]),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            dim=IOKey(type=int | tuple[int, ...] | None, value=dim),
         )
         self.factory_inputs = {"input": input}
         self._set_constraint(fn=size_constraints, keys=["output", "input", "dim"])
@@ -573,11 +574,13 @@ class PrimitiveSlice(PrimitiveModel):
         super().__init__(
             formula_key="sequence_slice",
             name=name,
-            output=Scalar(tuple[int | float | bool, ...] | list[int | float | bool]),
-            input=Scalar(tuple[int | float | bool, ...] | list[int | float | bool]),
-            start=Scalar(int | None, start),
-            stop=Scalar(int | None, stop),
-            step=Scalar(int | None, step),
+            output=IOKey(
+                type=tuple[int | float | bool, ...] | list[int | float | bool]
+            ),
+            input=IOKey(type=tuple[int | float | bool, ...] | list[int | float | bool]),
+            start=IOKey(type=int | None, value=start),
+            stop=IOKey(type=int | None, value=stop),
+            step=IOKey(type=int | None, value=step),
         )
 
         self.factory_inputs = {"input": input}
@@ -618,11 +621,11 @@ class TensorSlice(PrimitiveModel):
         super().__init__(
             formula_key="tensor_slice",
             name=name,
-            output=TensorType(["a", ("Var1", ...)]),
-            input=TensorType(["b", ("Var1", ...)]),
-            start=Scalar(int | None, start),
-            stop=Scalar(int | None, stop),
-            step=Scalar(int | None, step),
+            output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+            input=IOKey(shape=["b", ("Var1", ...)], type=GenericTensorType),
+            start=IOKey(type=int | None, value=start),
+            stop=IOKey(type=int | None, value=stop),
+            step=IOKey(type=int | None, value=step),
         )
         self.factory_inputs = {"input": input}
 
@@ -657,8 +660,8 @@ class Item(PrimitiveModel):
         super().__init__(
             formula_key="item",
             name=name,
-            output=Scalar(int | float),
-            input=TensorType([("Var", ...)]),
+            output=IOKey(type=int | float),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
         self._set_constraint(
@@ -687,9 +690,9 @@ class ScalarItem(PrimitiveModel):
         super().__init__(
             formula_key="scalar_item",
             name=name,
-            output=Scalar(int | float | list | tuple),
-            input=Scalar(list | tuple),
-            index=Scalar(int, index),
+            output=IOKey(type=int | float | list | tuple),
+            input=IOKey(type=list | tuple),
+            index=IOKey(type=int, value=index),
         )
         self.factory_inputs = {"input": input, "index": index}
 
@@ -725,15 +728,15 @@ class TensorItem(PrimitiveModel):
         super().__init__(
             formula_key="tensor_item",
             name=name,
-            output=TensorType([("Var2", ...)]),
-            input=TensorType([("Var1", ...)]),
-            index=Scalar(
-                int
+            output=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            index=IOKey(
+                type=int
                 | slice
                 | EllipsisType
                 | None
                 | tuple[int | slice | EllipsisType | None, ...],
-                index,
+                value=index,
             ),
         )
         self.factory_inputs = {"input": input, "index": index}
@@ -765,8 +768,8 @@ class ToTensor(PrimitiveModel):
         super().__init__(
             formula_key="to_tensor",
             name=name,
-            output=TensorType([("Var", ...)]),
-            input=Scalar(int | float | list | tuple),
+            output=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            input=IOKey(type=int | float | list | tuple),
         )
 
         self._set_constraint(
@@ -786,9 +789,9 @@ class ToList(PrimitiveModel):
     def __init__(self, n: int, name: str | None = None, **kwargs) -> None:
         self.factory_args = {"n": n}
         key_definitions = {}
-        key_definitions["output"] = Scalar(list[int | float | bool | list | tuple])
+        key_definitions["output"] = IOKey(type=list[int | float | bool | list | tuple])
         key_definitions |= {
-            f"input{idx+1}": Scalar(int | float | bool | list | tuple)
+            f"input{idx+1}": IOKey(type=int | float | bool | list | tuple)
             for idx in range(n)
         }
         self.factory_inputs = kwargs
@@ -811,8 +814,8 @@ class TensorToList(PrimitiveModel):
         super().__init__(
             formula_key="tensor_to_list",
             name=name,
-            output=Scalar(NestedListType(int | float | bool)),
-            input=TensorType([("Var", ...)]),
+            output=IOKey(type=NestedListType(int | float | bool)),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input}
         self._set_constraint(
@@ -842,7 +845,7 @@ class Reduce(PrimitiveModel):
         name: str | None = None,
         axis: int | tuple[int, ...] | None | ToBeDetermined = None,
         keepdim: bool | ToBeDetermined = False,
-        **kwargs: TensorType | Scalar,
+        **kwargs: IOKey,
     ) -> None:
         # TODO: Handle axis type for conditional cases below.
         self.factory_args = {"axis": axis, "keepdim": keepdim}
@@ -857,13 +860,12 @@ class Reduce(PrimitiveModel):
         else:
             raise ValueError("Requires valid axis type!")
 
-        init_kwargs: dict[str, TensorType | Scalar] = {
-            "output": TensorType([("Var_out", ...)]),
-            "input": TensorType([("Var_in", ...)]),
-            "axis": Scalar(axis_type, axis),
-            "keepdim": Scalar(bool, keepdim),
+        init_kwargs: dict[str, IOKey] = {
+            "output": IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+            "input": IOKey(shape=[("Var_in", ...)], type=GenericTensorType),
+            "axis": IOKey(type=axis_type, value=axis),
+            "keepdim": IOKey(type=bool, value=keepdim),
         }
-
         super().__init__(formula_key=formula_key, name=name, **(init_kwargs | kwargs))
 
         self._set_constraint(
@@ -895,7 +897,7 @@ class Mean(Reduce):
             name=name,
             axis=axis,
             keepdim=keepdim,
-            output=TensorType([("Var_out", ...)], float),
+            output=IOKey(shape=[("Var_out", ...)], type=MyTensor[float]),
         )
         self.factory_inputs = {"input": input, "axis": axis, "keepdim": keepdim}
         # self.factory_inputs = {"input": input}
@@ -950,7 +952,7 @@ class ArgMax(Reduce):
             axis=axis,
             keepdim=keepdim,
             # axis = Scalar(axis_type, axis), # TODO: Change axis type to int
-            output=TensorType([("Var_out", ...)], int),
+            output=IOKey(shape=[("Var_out", ...)], type=MyTensor[int]),
         )
         self.factory_inputs = {"input": input, "axis": axis, "keepdim": keepdim}
 
@@ -987,7 +989,7 @@ class ArgMin(Reduce):
             axis=axis,
             keepdim=keepdim,
             # axis = Scalar(axis_type, axis), # TODO: Change axis type to int
-            output=TensorType([("Var_out", ...)], int),
+            output=IOKey(shape=[("Var_out", ...)], type=MyTensor[int]),
         )
         self.factory_inputs = {"input": input, "axis": axis, "keepdim": keepdim}
 
@@ -1025,8 +1027,8 @@ class Variance(Reduce):
             name=name,
             axis=axis,
             keepdim=keepdim,
-            correction=Scalar(float | int | None, correction),
-            output=TensorType([("Var_out", ...)], float),
+            correction=IOKey(type=float | int | None, value=correction),
+            output=IOKey(shape=[("Var_out", ...)], type=MyTensor[float]),
         )
         self.factory_args = {"axis": axis, "correction": correction, "keepdim": keepdim}
         # TODO: Should we remove axis, correction and keepdim from factory_args?
@@ -1063,13 +1065,14 @@ class SingleInputOperation(PrimitiveModel):
         formula_key: str,
         polymorphic_constraint: bool = True,
         name: str | None = None,
-        **kwargs: TensorType | Scalar,
+        **kwargs: IOKey,
     ) -> None:
         default_kwargs = dict(
-            output=TensorType([("Var", ...)]), input=TensorType([("Var", ...)])
+            output=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
         )
         # Finalize kwargs.
-        new_kwargs: Mapping[str, TensorType | Scalar] = default_kwargs | kwargs
+        new_kwargs: Mapping[str, IOKey] = default_kwargs | kwargs
         super().__init__(formula_key, name=name, **new_kwargs)
 
         if polymorphic_constraint:
@@ -1119,16 +1122,16 @@ class Sqrt(PrimitiveModel):
             super().__init__(
                 formula_key="robust_sqrt",
                 name=name,
-                output=TensorType([("Var", ...)], float),
-                input=TensorType([("Var", ...)]),
-                cutoff=TensorType([], ConstantType),
+                output=IOKey(shape=[("Var", ...)], type=MyTensor[float]),
+                input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+                cutoff=IOKey(shape=[], type=GenericTensorType),
             )
             self.factory_inputs = {"input": input, "cutoff": cutoff}
         else:
             super().__init__(
                 formula_key="sqrt",
-                output=TensorType([("Var", ...)], float),
-                input=TensorType([("Var", ...)]),
+                output=IOKey(shape=[("Var", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var", ...)], type=GenericTensorType),
             )
             self.factory_inputs = {"input": input}
 
@@ -1159,9 +1162,9 @@ class RelationalOperators(PrimitiveModel):
         super().__init__(
             formula_key=formula_key,
             name=name,
-            output=TensorType([("Var1", ...)], bool),
-            left=TensorType([("Var2", ...)]),
-            right=TensorType([("Var3", ...)]),
+            output=IOKey(shape=[("Var1", ...)], type=MyTensor[bool]),
+            left=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
+            right=IOKey(shape=[("Var3", ...)], type=GenericTensorType),
         )
 
         self._set_constraint(bcast, ["output", "left", "right"])
@@ -1251,8 +1254,8 @@ class LogicalNot(PrimitiveModel):
         super().__init__(
             formula_key="logical_not",
             name=name,
-            output=TensorType([("Var", ...)], bool),
-            input=TensorType([("Var", ...)], bool),
+            output=IOKey(shape=[("Var", ...)], type=MyTensor[bool]),
+            input=IOKey(shape=[("Var", ...)], type=MyTensor[bool]),
         )
         self.factory_inputs = {"input": input}
 
@@ -1277,9 +1280,9 @@ class BitwiseOperators(PrimitiveModel):
         super().__init__(
             formula_key=formula_key,
             name=name,
-            output=TensorType([("Var1", ...)], bool),
-            left=TensorType([("Var2", ...)], bool),
-            right=TensorType([("Var3", ...)], bool),
+            output=IOKey(shape=[("Var1", ...)], type=MyTensor[bool]),
+            left=IOKey(shape=[("Var2", ...)], type=MyTensor[bool]),
+            right=IOKey(shape=[("Var3", ...)], type=MyTensor[bool]),
         )
         self.factory_inputs = {"left": left, "right": right}
         self._set_constraint(bcast, ["output", "left", "right"])
@@ -1341,9 +1344,9 @@ class ShiftLeft(PrimitiveModel):
         super().__init__(
             formula_key="shift_left",
             name=name,
-            output=TensorType([("Var3", ...)], int),
-            input=TensorType([("Var1", ...)], int),
-            shift=TensorType([("Var2", ...)], int),
+            output=IOKey(shape=[("Var3", ...)], type=MyTensor[int]),
+            input=IOKey(shape=[("Var1", ...)], type=MyTensor[int]),
+            shift=IOKey(shape=[("Var2", ...)], type=MyTensor[int]),
         )
         self.factory_inputs = {"input": input, "shift": shift}
 
@@ -1372,9 +1375,9 @@ class ShiftRight(PrimitiveModel):
         super().__init__(
             formula_key="shift_right",
             name=name,
-            output=TensorType([("Var3", ...)], int),
-            input=TensorType([("Var1", ...)], int),
-            shift=TensorType([("Var2", ...)], int),
+            output=IOKey(shape=[("Var3", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            shift=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
         )
         self.factory_inputs = {"input": input, "shift": shift}
 
@@ -1408,9 +1411,9 @@ class Transpose(PrimitiveModel):
             super().__init__(
                 formula_key="transpose",
                 name=name,
-                output=TensorType([("Var_out", ...)]),
-                input=TensorType([("Var_in", ...)]),
-                axes=Scalar(NoneType, axes),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var_in", ...)], type=GenericTensorType),
+                axes=IOKey(type=NoneType, value=axes),
             )
             self.factory_inputs = {"input": input, "axes": axes}
             self._set_constraint(
@@ -1423,24 +1426,26 @@ class Transpose(PrimitiveModel):
             output_shapes = [input_shapes[i] for i in axes]
             super().__init__(
                 formula_key="transpose",
-                output=TensorType(output_shapes),
-                input=TensorType(input_shapes),
-                axes=Scalar(int | tuple[int, ...], axes),
+                name=name,
+                output=IOKey(shape=output_shapes, type=GenericTensorType),
+                input=IOKey(shape=input_shapes, type=GenericTensorType),
+                axes=IOKey(type=int | tuple[int, ...], value=axes),
             )
 
         elif axes is TBD:
             super().__init__(
                 formula_key="transpose",
-                output=TensorType([("Var_out", ...)]),
-                input=TensorType([("Var_in", ...)]),
-                axes=Scalar(int | tuple[int, ...] | None, axes),
+                name=name,
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var_in", ...)], type=GenericTensorType),
+                axes=IOKey(type=int | tuple[int, ...] | None, value=axes),
             )
             self._set_constraint(
                 fn=reverse_constraints, keys=["output", "input", "axes"]
             )
 
         self._set_constraint(
-            fn=general_tensor_type_constraint, keys=[PrimitiveModel.output_key, "input"]
+            fn=general_tensor_type_constraint, keys=["output", "input"]
         )
 
     def __call__(  # type: ignore[override]
@@ -1468,10 +1473,10 @@ class Split(PrimitiveModel):
         super().__init__(
             formula_key="split",
             name=name,
-            output=TensorType([("Var2", ...)]),
-            input=TensorType([("Var1", ...)]),
-            split_size=Scalar(int | tuple[int], split_size),
-            axis=Scalar(int, axis),
+            output=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            split_size=IOKey(type=int | tuple[int], value=split_size),
+            axis=IOKey(type=int, value=axis),
         )
         self.factory_inputs = {"input": input, "split_size": split_size, "axis": axis}
 

--- a/mithril/framework/logical/model.py
+++ b/mithril/framework/logical/model.py
@@ -34,6 +34,7 @@ from ..common import (
     KeyType,
     MainValueInstance,
     MainValueType,
+    NestedListType,
     NotAvailable,
     NullConnection,
     Scalar,
@@ -695,9 +696,10 @@ class Model(BaseModel):
                 data = Scalar(possible_types=set_type)
 
             else:
+                shape_node = ShapeRepr(root=Variadic()).node
                 if set_type is None:
                     set_type = int | float | bool
-                shape_node = ShapeRepr(root=Variadic()).node
+                assert isinstance(set_type, type | UnionType)
                 data = Tensor(shape_node, set_type)
 
             # Determine connection type.
@@ -1065,7 +1067,7 @@ class Model(BaseModel):
         output_values: set[str] = set()
 
         shape_info: dict[str, ShapeTemplateType] = dict()
-        type_info: dict[str, type | UnionType] = dict()
+        type_info: dict[str, type | UnionType | NestedListType] = dict()
 
         for key, value in kwargs.items():
             # Check if given keys are among model's keys.

--- a/mithril/framework/logical/primitive.py
+++ b/mithril/framework/logical/primitive.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from collections.abc import Mapping
-from typing import Any
+from functools import reduce
+from typing import Any, Union, get_origin
 
 from ...utils.utils import OrderedSet
 from ..common import (
@@ -21,18 +22,21 @@ from ..common import (
     TBD,
     Connection,
     IOHyperEdge,
+    IOKey,
     KeyType,
     NotAvailable,
     Scalar,
     Tensor,
-    TensorType,
     UniadicRecord,
     Updates,
     Variadic,
     create_shape_map,
+    get_args,
+    get_mytensor_subtype,
     get_summary,
     get_summary_shapes,
     get_summary_types,
+    is_mytensor_type,
 )
 from .base import BaseModel
 
@@ -50,7 +54,7 @@ class PrimitiveModel(BaseModel):
         self,
         formula_key: str,
         name: str | None = None,
-        **kwargs: Tensor[Any] | TensorType | Scalar,
+        **kwargs: IOKey | Tensor | Scalar,
     ) -> None:
         self.formula_key = formula_key
         self.grad_formula = formula_key + "_grad"
@@ -58,27 +62,61 @@ class PrimitiveModel(BaseModel):
         super().__init__(name=name)
         # Get shape_templates of TensorTypes and create corresponding shapes.
         shape_templates = {
-            key: value.shape_template
+            key: value._shape
             for key, value in kwargs.items()
-            if isinstance(value, TensorType)
+            if isinstance(value, IOKey) and value._shape is not None
         }
         shapes = create_shape_map(shape_templates, self.constraint_solver)
         data_set: set[Tensor[Any]] = set()
         is_diff = False
         output_data: Tensor[Any] | Scalar | None = None
         for key, value in kwargs.items():
-            if isinstance(value, TensorType):
-                value = value.construct(shapes[key].node)
-                data_set.add(value)
+            # TODO: The first if block is temporary. All if else blocks will be
+            # removed after the implementation of the new type system.
+            if get_origin(value._type) is Union:
+                args = get_args(value._type)
+                types = []
+                for _type in args:
+                    # TODO: assertion will be removed,
+                    # we should allow Scalar|Tensor type simultaneously.
+                    assert is_mytensor_type(_type)
+                    types.append(get_mytensor_subtype(_type))
+                possible_types = reduce(lambda x, y: x | y, types)  # type: ignore
 
-            conn_data = self.create_connection(IOHyperEdge(value), key)
+                assert isinstance(value, IOKey)
+                _value: Tensor | Scalar = Tensor(
+                    shape=shapes[key].node,
+                    possible_types=possible_types,
+                    value=value._value,  # type: ignore
+                    interval=value._interval,
+                )
+                assert isinstance(_value, Tensor)
+                data_set.add(_value)
+            elif is_mytensor_type(value._type):
+                assert isinstance(value, IOKey)
+                _value = Tensor(
+                    shape=shapes[key].node,
+                    possible_types=get_mytensor_subtype(value._type),  # type: ignore
+                    value=value._value,  # type: ignore
+                    interval=value._interval,
+                )
+                data_set.add(_value)
+            elif isinstance(value, Tensor | Scalar):
+                _value = value
+            else:
+                _value = Scalar(
+                    possible_types=value._type,  # type: ignore
+                    value=value._value,  # type: ignore
+                )
+
+            conn_data = self.create_connection(IOHyperEdge(_value), key)
 
             if key == PrimitiveModel.output_key:
                 self.conns.set_connection_type(conn_data, KeyType.OUTPUT)
-                output_data = value
+                output_data = _value
             else:
                 self.conns.set_connection_type(conn_data, KeyType.INPUT)
-                is_diff |= not value.is_non_diff
+                is_diff |= not _value.is_non_diff
         if isinstance(output_data, Tensor):
             output_data._differentiable = is_diff
 

--- a/tests/scripts/test_constr_counter.py
+++ b/tests/scripts/test_constr_counter.py
@@ -19,6 +19,9 @@ from mithril.framework import Scalar, Tensor
 from mithril.framework.common import (
     NOT_GIVEN,
     ConnectionType,
+    GenericTensorType,
+    IOKey,
+    MyTensor,
     ShapeRepr,
     Uniadic,
     Updates,
@@ -33,7 +36,6 @@ from mithril.models import (
     PrimitiveModel,
     Relu,
     TensorSlice,
-    TensorType,
     Transpose,
 )
 
@@ -96,8 +98,8 @@ class Model1(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...)]),
-            output=TensorType([("Var2", ...)]),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
         )
         self._set_constraint(fn=dummy_constraint, keys=["output", "input"])
 
@@ -109,8 +111,8 @@ class Model2(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...)]),
-            output=TensorType([("Var2", ...)]),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
         )
         self._set_constraint(fn=dummy_constraint, keys=["output", "input"])
         self._set_constraint(
@@ -125,8 +127,8 @@ class Model3(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...)], int | bool),
-            output=TensorType([("Var2", ...)], int | bool),
+            input=IOKey(shape=[("Var1", ...)], type=MyTensor[int] | MyTensor[bool]),
+            output=IOKey(shape=[("Var2", ...)], type=MyTensor[int] | MyTensor[bool]),
         )
         self._set_constraint(fn=dummy_constraint, keys=["output", "input"])
 
@@ -139,9 +141,9 @@ class MyAdd2(PrimitiveModel):
     def __init__(self, left, right, output) -> None:
         super().__init__(
             formula_key="add",
-            output=TensorType(output),
-            left=TensorType(left),
-            right=TensorType(right),
+            output=IOKey(shape=output, type=GenericTensorType),
+            left=IOKey(shape=left, type=GenericTensorType),
+            right=IOKey(shape=right, type=GenericTensorType),
         )
         self._set_constraint(
             fn=bcast, keys=[PrimitiveModel.output_key, "left", "right"]

--- a/tests/scripts/test_functions.py
+++ b/tests/scripts/test_functions.py
@@ -20,6 +20,7 @@ import mithril
 from mithril import CBackend, JaxBackend, NumpyBackend, TorchBackend
 from mithril.backends.with_manualgrad.numpy_backend.ops_grad import add_grad
 from mithril.framework import NOT_GIVEN, ConnectionType, ExtendInfo
+from mithril.framework.common import GenericTensorType, IOKey
 from mithril.framework.constraints import bcast
 from mithril.models import (
     Absolute,
@@ -31,7 +32,6 @@ from mithril.models import (
     Cosine,
     CrossEntropy,
     Divide,
-    IOKey,
     Layer,
     Linear,
     LinearSVM,
@@ -47,7 +47,6 @@ from mithril.models import (
     Softmax,
     Softplus,
     Subtract,
-    TensorType,
     TrainModel,
 )
 from mithril.utils.utils import BiMultiMap
@@ -408,9 +407,9 @@ def test_code_generator_4(file_path: str):
         def __init__(self) -> None:
             super().__init__(
                 formula_key="my_adder",
-                output=TensorType([("Var_out", ...)]),
-                input=TensorType([("Var_1", ...)]),
-                rhs=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                rhs=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(
                 fn=bcast, keys=[PrimitiveModel.output_key, "input", "rhs"]
@@ -534,9 +533,9 @@ def test_code_generator_5(file_path: str):
         def __init__(self) -> None:
             super().__init__(
                 formula_key="my_adder",
-                output=TensorType([("Var_out", ...)]),
-                input=TensorType([("Var_1", ...)]),
-                rhs=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                rhs=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(
                 fn=bcast, keys=[PrimitiveModel.output_key, "input", "rhs"]

--- a/tests/scripts/test_jittable.py
+++ b/tests/scripts/test_jittable.py
@@ -29,6 +29,7 @@ from mithril.backends.with_autograd.jax_backend.ops import (
     to_tensor,
 )
 from mithril.framework import NOT_GIVEN, ConnectionType, ExtendInfo
+from mithril.framework.common import GenericTensorType
 from mithril.framework.constraints import bcast
 from mithril.models import (
     TBD,
@@ -45,7 +46,6 @@ from mithril.models import (
     Reshape,
     ScalarItem,
     Shape,
-    TensorType,
     ToTensor,
 )
 
@@ -220,9 +220,9 @@ def test_mymodel_jax():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="adder",
-                output=TensorType([("Var_out", ...)]),
-                left=TensorType([("Var_1", ...)]),
-                right=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                left=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                right=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(fn=bcast, keys=["output", "left", "right"])
 
@@ -342,9 +342,9 @@ def test_jit_1():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="adder",
-                output=TensorType([("Var_out", ...)]),
-                left=TensorType([("Var_1", ...)]),
-                right=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                left=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                right=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(fn=bcast, keys=["output", "left", "right"])
 

--- a/tests/scripts/test_model_to_dict_rtt.py
+++ b/tests/scripts/test_model_to_dict_rtt.py
@@ -16,7 +16,7 @@ import re
 
 import mithril
 from mithril import JaxBackend, TorchBackend
-from mithril.framework.common import TBD, IOKey
+from mithril.framework.common import TBD, GenericTensorType, IOKey
 from mithril.framework.constraints import squeeze_constraints
 from mithril.models import (
     L2,
@@ -32,10 +32,8 @@ from mithril.models import (
     Mean,
     Model,
     Relu,
-    Scalar,
     Sigmoid,
     SquaredError,
-    TensorType,
     TrainModel,
 )
 from mithril.utils import dict_conversions
@@ -843,7 +841,7 @@ def test_set_values_ellipsis_2():
     assert_models_equal(model, model_recreated)
 
 
-def test_make_shape_constrain():
+def test_make_shape_constraint():
     model = Model()
 
     def my_adder(input, rhs):
@@ -856,9 +854,9 @@ def test_make_shape_constrain():
             threshold *= 2
             super().__init__(
                 formula_key="my_adder",
-                output=TensorType([("Var_out", ...)]),
-                input=TensorType([("Var_1", ...)]),
-                rhs=Scalar(int, threshold),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                input=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                rhs=IOKey(type=int, value=threshold),
             )
             self.set_constraint(
                 fn=squeeze_constraints, keys=[CustomPrimitiveModel.output_key, "input"]

--- a/tests/scripts/test_ref_counts.py
+++ b/tests/scripts/test_ref_counts.py
@@ -21,6 +21,7 @@ from mithril.framework.common import (
     Connect,
     Connection,
     ConnectionType,
+    GenericTensorType,
     ShapeTemplateType,
     Tensor,
 )
@@ -40,7 +41,6 @@ from mithril.models import (
     Relu,
     Sigmoid,
     Sum,
-    TensorType,
 )
 
 from .test_utils import (
@@ -82,8 +82,8 @@ def test_deleted_variadic_ref_count_1() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b", ("Var1", ...)]),
-                output=TensorType(["c", "d", ("Var2", ...)]),
+                input=IOKey(shape=["a", "b", ("Var1", ...)], type=GenericTensorType),
+                output=IOKey(shape=["c", "d", ("Var2", ...)], type=GenericTensorType),
             )
 
     model = Model()
@@ -115,8 +115,8 @@ def test_deleted_variadic_ref_count_2() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...)]),
-                output=TensorType([("Var1", ...)]),
+                input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+                output=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
             )
 
     buff_model1 = MyModel()
@@ -339,8 +339,8 @@ def test_deleted_uniadic_ref_count_5():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     all_uniadics = set()
@@ -378,8 +378,8 @@ def test_deleted_uniadic_ref_count_7():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b", "c"]),
-                output=TensorType(["c", "d", "e"]),
+                input=IOKey(shape=["a", "b", "c"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d", "e"], type=GenericTensorType),
             )
 
     all_uniadics = set()
@@ -403,8 +403,8 @@ def test_deleted_uniadic_ref_count_8():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b", "c"]),
-                output=TensorType(["d", "e", "f"]),
+                input=IOKey(shape=["a", "b", "c"], type=GenericTensorType),
+                output=IOKey(shape=["d", "e", "f"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -434,8 +434,8 @@ def test_deleted_uniadic_ref_count_9():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([1, 1, 1]),
-                output=TensorType([1, 1, 1]),
+                input=IOKey(shape=[1, 1, 1], type=GenericTensorType),
+                output=IOKey(shape=[1, 1, 1], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -558,8 +558,8 @@ def test_deleted_repr_ref_count_5() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "a"]),
-                output=TensorType(["a", ("Var1", ...)]),
+                input=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -612,8 +612,8 @@ def test_deleted_repr_ref_count_6() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "a"]),
-                output=TensorType(["a", ("Var1", ...)]),
+                input=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -665,8 +665,8 @@ def test_deleted_repr_ref_count_7() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "a"]),
-                output=TensorType(["a", ("Var1", ...)]),
+                input=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -701,8 +701,8 @@ def test_deleted_repr_ref_count_8() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["b", "a"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["b", "a"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -1259,8 +1259,8 @@ def test_deleted_uniadic_ref_count_2() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a1"]),
-                output=TensorType(["a2"]),
+                input=IOKey(shape=["a1"], type=GenericTensorType),
+                output=IOKey(shape=["a2"], type=GenericTensorType),
             )
 
     buff_model1 = MyModel()
@@ -1299,8 +1299,8 @@ def test_deleted_uniadic_ref_count() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     model = Model()
@@ -1331,8 +1331,8 @@ def test_deleted_repr_ref_count() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     model = Model()
@@ -1363,8 +1363,8 @@ def test_deleted_node_ref_count() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     model = Model()
@@ -1393,8 +1393,8 @@ def test_deleted_tensor_ref_count() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     model = Model()
@@ -1421,8 +1421,8 @@ def test_deleted_edge_ref_count() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["c", "d"], type=GenericTensorType),
             )
 
     model = Model()

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -35,6 +35,8 @@ from mithril.framework.common import (
     TBD,
     ConnectionData,
     ConnectionType,
+    GenericTensorType,
+    IOKey,
     NotAvailable,
     OrderedSet,
     ToBeDetermined,
@@ -69,7 +71,6 @@ from mithril.models import (
     FloorDivide,
     Gelu,
     Greater,
-    IOKey,
     Layer,
     LeakyRelu,
     Less,
@@ -103,7 +104,6 @@ from mithril.models import (
     Sum,
     Tanh,
     Tensor,
-    TensorType,
     ToTensor,
     TrainModel,
     Where,
@@ -1203,9 +1203,9 @@ def test_reuse_pickled_registered_backend():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="my_adder",
-                output=TensorType([("Var_out", ...)]),
-                left=TensorType([("Var_1", ...)]),
-                right=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                left=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                right=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(
                 fn=bcast, keys=[PrimitiveModel.output_key, "left", "right"]
@@ -4378,9 +4378,9 @@ def test_infer_static_register_fn():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="my_adder",
-                output=TensorType([("Var_out", ...)]),
-                left=TensorType([("Var_1", ...)]),
-                right=TensorType([("Var_2", ...)]),
+                output=IOKey(shape=[("Var_out", ...)], type=GenericTensorType),
+                left=IOKey(shape=[("Var_1", ...)], type=GenericTensorType),
+                right=IOKey(shape=[("Var_2", ...)], type=GenericTensorType),
             )
             self.set_constraint(
                 fn=bcast, keys=[PrimitiveModel.output_key, "left", "right"]
@@ -7323,19 +7323,19 @@ def test_string_iokey_value_1():
                 # Parse the shapes
                 all_input_shapes = list(input)
                 all_output_shapes = list(output)
-                # Create TensorType and Scalar Inputs
+                # Create IOKey shape = and Scalar Input, type = GenericTensorTypes
                 # Note that equation is string
-                tensor_input = TensorType(all_input_shapes)
-                tensor_output = TensorType(all_output_shapes)
-                scalar_equation = Scalar(str, equation)
+                tensor_input = IOKey(shape=all_input_shapes, type=GenericTensorType)
+                tensor_output = IOKey(shape=all_output_shapes, type=GenericTensorType)
+                scalar_equation = IOKey(type=str, value=equation)
 
             else:
                 # case where equation is TBD
-                tensor_input = TensorType([("Var1", ...)])
-                tensor_output = TensorType([("Var2", ...)])
-                scalar_equation = Scalar(str)
+                tensor_input = IOKey(shape=[("Var1", ...)], type=GenericTensorType)
+                tensor_output = IOKey(shape=[("Var2", ...)], type=GenericTensorType)
+                scalar_equation = IOKey(type=str)
 
-            kwargs: dict[str, TensorType | Scalar] = {
+            kwargs: dict[str, IOKey] = {
                 "output": tensor_output,
                 "input": tensor_input,
                 "equation": scalar_equation,
@@ -7409,17 +7409,17 @@ def test_string_iokey_value_2():
                 all_output_shapes = list(output)
                 # Create TensorType and Scalar Inputs
                 # Note that equation is string
-                tensor_input = TensorType(all_input_shapes)
-                tensor_output = TensorType(all_output_shapes)
-                scalar_equation = Scalar(str, equation)
+                tensor_input = IOKey(shape=all_input_shapes, type=GenericTensorType)
+                tensor_output = IOKey(shape=all_output_shapes, type=GenericTensorType)
+                scalar_equation = IOKey(type=str, value=equation)
 
             else:
                 # case where equation is TBD
-                tensor_input = TensorType([("Var1", ...)])
-                tensor_output = TensorType([("Var2", ...)])
-                scalar_equation = Scalar(str)
+                tensor_input = IOKey(shape=[("Var1", ...)], type=GenericTensorType)
+                tensor_output = IOKey(shape=[("Var2", ...)], type=GenericTensorType)
+                scalar_equation = IOKey(type=str)
 
-            kwargs: dict[str, TensorType | Scalar] = {
+            kwargs: dict[str, IOKey] = {
                 "output": tensor_output,
                 "input": tensor_input,
                 "equation": scalar_equation,

--- a/tests/scripts/test_shapes.py
+++ b/tests/scripts/test_shapes.py
@@ -30,8 +30,9 @@ from mithril.framework.common import (
     Connection,
     ConnectionType,
     Equivalences,
+    GenericTensorType,
+    IOKey,
     PossibleValues,
-    Scalar,
     ShapeNode,
     ShapeRepr,
     Uniadic,
@@ -70,7 +71,6 @@ from mithril.models import (
     Gelu,
     GPRAlpha,
     GPRVOuter,
-    IOKey,
     IsNan,
     Layer,
     LeakyRelu,
@@ -110,7 +110,6 @@ from mithril.models import (
     SwapAxes,
     Tanh,
     Tensor,
-    TensorType,
     ToList,
     ToTuple,
     TrainModel,
@@ -3064,8 +3063,8 @@ class Model1(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType([("Var1", ...)]),
-            output=TensorType([("Var1", ...), "u1", "u2"]),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "u1", "u2"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3081,8 +3080,8 @@ class Model2(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType([("Var1", ...), "u1"]),
-            output=TensorType(["u1", ("Var1", ...)]),
+            input=IOKey(shape=[("Var1", ...), "u1"], type=GenericTensorType),
+            output=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3100,10 +3099,10 @@ class Model3(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="concat",
-            input1=TensorType(["u1", "u2", "u3"]),
-            input2=TensorType(["u3", "u2", "u1"]),
-            output=TensorType(["u1", ("Var1", ...), "u3"]),
-            axis=Scalar(int),
+            input1=IOKey(shape=["u1", "u2", "u3"], type=GenericTensorType),
+            input2=IOKey(shape=["u3", "u2", "u1"], type=GenericTensorType),
+            output=IOKey(shape=["u1", ("Var1", ...), "u3"], type=GenericTensorType),
+            axis=IOKey(type=int),
         )
 
     def __call__(  # type: ignore[override]
@@ -3122,8 +3121,8 @@ class Model4(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType([("Var1", ...)]),
-            output=TensorType([("Var1", ...), 1]),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), 1], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3140,9 +3139,9 @@ class Model5(PrimitiveModel):
     def __init__(self, axis=None) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType([("Var1", ...)]),
-            output=TensorType([("Var2", ...)]),
-            axis=Scalar(possible_types=NoneType | list[int], value=axis),
+            input=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var2", ...)], type=GenericTensorType),
+            axis=IOKey(type=NoneType | list[int], value=axis),
         )
 
     def __call__(  # type: ignore[override]
@@ -3161,8 +3160,8 @@ class Model6(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType(["u1", ("Var1", ...)]),
-            output=TensorType([("Var1", ...), "u1"]),
+            input=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "u1"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3178,8 +3177,8 @@ class Model7(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType(["u1", ("Var1", ...)]),
-            output=TensorType(["u1", ("Var1", ...)]),
+            input=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3195,8 +3194,8 @@ class Model8(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="relu",
-            input=TensorType([("Var1", ...), "u1"]),
-            output=TensorType([("Var1", ...), "u1"]),
+            input=IOKey(shape=[("Var1", ...), "u1"], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "u1"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -3212,8 +3211,8 @@ class Model9(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType(["u1", ("Var1", ...)]),
-            output=TensorType(["u2", "u1", ("Var1", ...)]),
+            input=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["u2", "u1", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4106,8 +4105,8 @@ class MyVariadic1(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...), "a"]),
-            output=TensorType([("Var1", ...), "a"]),
+            input=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4123,8 +4122,8 @@ class MyVariadic2(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...), "a", "b"]),
-            output=TensorType([("Var1", ...), "a", "b"]),
+            input=IOKey(shape=[("Var1", ...), "a", "b"], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "a", "b"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4140,8 +4139,8 @@ class MyVariadic3(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType(["a", "b", ("Var1", ...)]),
-            output=TensorType(["a", "b", ("Var1", ...)]),
+            input=IOKey(shape=["a", "b", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["a", "b", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4157,8 +4156,8 @@ class MyVariadic4(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType(["a", ("Var1", ...)]),
-            output=TensorType(["a", ("Var1", ...)]),
+            input=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4174,8 +4173,8 @@ class MyVariadic5(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...), "a", "b"]),
-            output=TensorType([("Var1", ...), "a"]),
+            input=IOKey(shape=[("Var1", ...), "a", "b"], type=GenericTensorType),
+            output=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4191,8 +4190,8 @@ class MyVariadic6(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...), "a"]),
-            output=TensorType(["a", "a"]),
+            input=IOKey(shape=[("Var1", ...), "a"], type=GenericTensorType),
+            output=IOKey(shape=["a", "a"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4208,8 +4207,8 @@ class MyVariadic7(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType([("Var1", ...), "u1", "u2"]),
-            output=TensorType(["u3", ("Var2", ...), "u4"]),
+            input=IOKey(shape=[("Var1", ...), "u1", "u2"], type=GenericTensorType),
+            output=IOKey(shape=["u3", ("Var2", ...), "u4"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4230,13 +4229,30 @@ class MyVariadic8(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input1=TensorType(["u1", "u2", "u3", ("Var1", ...)]),
-            input2=TensorType(["u4", "u5", ("Var2", ...), "u6"]),
-            input3=TensorType(["u7", ("Var3", ...), "u8", "u9"]),
-            input4=TensorType([("Var4", ...), "u10", "u11", "u12"]),
-            input5=TensorType([("Var5", ...), "u13", "u14", "u15", "u16"]),
-            input6=TensorType(["u17", "u18", ("Var6", ...), "u19", "u20"]),
-            output=TensorType(["u13", ("Var1", ...), "u14", "u15", "u16"]),
+            input1=IOKey(
+                shape=["u1", "u2", "u3", ("Var1", ...)], type=GenericTensorType
+            ),
+            input2=IOKey(
+                shape=["u4", "u5", ("Var2", ...), "u6"], type=GenericTensorType
+            ),
+            input3=IOKey(
+                shape=["u7", ("Var3", ...), "u8", "u9"], type=GenericTensorType
+            ),
+            input4=IOKey(
+                shape=[("Var4", ...), "u10", "u11", "u12"], type=GenericTensorType
+            ),
+            input5=IOKey(
+                shape=[("Var5", ...), "u13", "u14", "u15", "u16"],
+                type=GenericTensorType,
+            ),
+            input6=IOKey(
+                shape=["u17", "u18", ("Var6", ...), "u19", "u20"],
+                type=GenericTensorType,
+            ),
+            output=IOKey(
+                shape=["u13", ("Var1", ...), "u14", "u15", "u16"],
+                type=GenericTensorType,
+            ),
         )
 
     def __call__(  # type: ignore[override]
@@ -4272,10 +4288,10 @@ class MyVariadic9(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input1=TensorType(["u1", ("Var1", ...)]),
-            input2=TensorType([("Var2", ...), "u2"]),
-            input3=TensorType(["u3", ("Var3", ...), "u4"]),
-            output=TensorType(["u5", "u5"]),
+            input1=IOKey(shape=["u1", ("Var1", ...)], type=GenericTensorType),
+            input2=IOKey(shape=[("Var2", ...), "u2"], type=GenericTensorType),
+            input3=IOKey(shape=["u3", ("Var3", ...), "u4"], type=GenericTensorType),
+            output=IOKey(shape=["u5", "u5"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4302,12 +4318,16 @@ class MyVariadic10(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input1=TensorType(["u1", "u2", ("Var1", ...)]),
-            input2=TensorType(["u3", ("Var2", ...), "u4"]),
-            input3=TensorType([("Var3", ...), "u5", "u6"]),
-            input4=TensorType(["u7", "u8", ("Var4", ...), "u9", "u10"]),
-            input5=TensorType(["u11", ("Var4", ...), "u12", "u13"]),
-            output=TensorType(["u5", "u5"]),
+            input1=IOKey(shape=["u1", "u2", ("Var1", ...)], type=GenericTensorType),
+            input2=IOKey(shape=["u3", ("Var2", ...), "u4"], type=GenericTensorType),
+            input3=IOKey(shape=[("Var3", ...), "u5", "u6"], type=GenericTensorType),
+            input4=IOKey(
+                shape=["u7", "u8", ("Var4", ...), "u9", "u10"], type=GenericTensorType
+            ),
+            input5=IOKey(
+                shape=["u11", ("Var4", ...), "u12", "u13"], type=GenericTensorType
+            ),
+            output=IOKey(shape=["u5", "u5"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4339,8 +4359,8 @@ class MyVariadic11(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType(["a", ("Var1", ...)]),
-            output=TensorType(["a", ("Var1", ...), "b"]),
+            input=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -4356,8 +4376,8 @@ class MyVariadic12(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="buffer",
-            input=TensorType(["a", "b", ("Var1", ...)]),
-            output=TensorType(["a", "b", "c", ("Var1", ...)]),
+            input=IOKey(shape=["a", "b", ("Var1", ...)], type=GenericTensorType),
+            output=IOKey(shape=["a", "b", "c", ("Var1", ...)], type=GenericTensorType),
         )
 
     def __call__(  # type: ignore[override]
@@ -5248,9 +5268,9 @@ def test_variadic_naming_14() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input1=TensorType(["a", ("Var1", ...), "b"]),
-                input2=TensorType([("Var1", ...)]),
-                output=TensorType(["a", ("Var1", ...), "c"]),
+                input1=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
+                input2=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...), "c"], type=GenericTensorType),
             )
 
     model = MyModel()
@@ -5280,9 +5300,9 @@ def test_variadic_naming_15() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input1=TensorType(["a", ("Var1", ...), "b"]),
-                input2=TensorType(["b", "c"]),
-                output=TensorType(["a", ("Var1", ...), "c"]),
+                input1=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
+                input2=IOKey(shape=["b", "c"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...), "c"], type=GenericTensorType),
             )
 
     model = MyModel()
@@ -5308,8 +5328,8 @@ def test_variadic_naming_16() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", ("Var1", ...), "b"]),
-                output=TensorType(["b", ("Var1", ...), "a"]),
+                input=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
+                output=IOKey(shape=["b", ("Var1", ...), "a"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -5349,8 +5369,8 @@ def test_variadic_naming_17() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", ("Var1", ...), "b"]),
-                output=TensorType(["b", ("Var1", ...), "a"]),
+                input=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
+                output=IOKey(shape=["b", ("Var1", ...), "a"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -5666,8 +5686,12 @@ def test_variadic_naming_25() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "a", "b", "c"]),
-                output=TensorType(["c", ("Var1", ...), "a", "b"]),
+                input=IOKey(
+                    shape=[("Var1", ...), "a", "b", "c"], type=GenericTensorType
+                ),
+                output=IOKey(
+                    shape=["c", ("Var1", ...), "a", "b"], type=GenericTensorType
+                ),
             )
 
         def __call__(  # type: ignore[override]
@@ -5709,10 +5733,10 @@ def test_variadic_naming_26() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input1=TensorType(["a", ("Var1", ...), "b"]),
-                input2=TensorType(["_a", ("Var1", ...), "_b"]),
-                input3=TensorType(["b", "c"]),
-                output=TensorType(["a", ("Var1", ...), "c"]),
+                input1=IOKey(shape=["a", ("Var1", ...), "b"], type=GenericTensorType),
+                input2=IOKey(shape=["_a", ("Var1", ...), "_b"], type=GenericTensorType),
+                input3=IOKey(shape=["b", "c"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...), "c"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -5759,8 +5783,8 @@ def test_variadic_naming_27() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "u1"]),
-                output=TensorType([("Var1", ...)]),
+                input=IOKey(shape=[("Var1", ...), "u1"], type=GenericTensorType),
+                output=IOKey(shape=[("Var1", ...)], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -5802,8 +5826,10 @@ def test_same_uniadic_1() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "u1", "u2", "u3"]),
-                output=TensorType([("Var1", ...), "u4"]),
+                input=IOKey(
+                    shape=[("Var1", ...), "u1", "u2", "u3"], type=GenericTensorType
+                ),
+                output=IOKey(shape=[("Var1", ...), "u4"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -5841,8 +5867,10 @@ def test_same_uniadic_2() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "u1", "u2", "u3"]),
-                output=TensorType([("Var1", ...), "u4"]),
+                input=IOKey(
+                    shape=[("Var1", ...), "u1", "u2", "u3"], type=GenericTensorType
+                ),
+                output=IOKey(shape=[("Var1", ...), "u4"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -6818,6 +6846,9 @@ def test_total_repr_count_1():
                 for shape in shapes:
                     reprs |= find_all_reprs(shape)
             if (ref_result := ref_counts.get(model.__class__)) is not None:
+                if len(reprs) != ref_result:
+                    ...
+                    model = primitive_model(**kwargs)
                 assert len(reprs) == ref_result
             else:
                 assert len(reprs) == len(all_tensor_conns)
@@ -7006,8 +7037,8 @@ def test_repr_count_1():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["b", "c", "d"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["b", "c", "d"], type=GenericTensorType),
             )
 
     model = MyModel()
@@ -7025,8 +7056,10 @@ def test_equalize_lengths_of_unmatchable_reprs_of_different_sizes_with_extend_1(
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", ("Var1", ...)]),
-                output=TensorType([("Var1", ...), "c", "d", "e"]),
+                input=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+                output=IOKey(
+                    shape=[("Var1", ...), "c", "d", "e"], type=GenericTensorType
+                ),
             )
 
     model = Model()
@@ -7048,8 +7081,10 @@ def test_equalize_lengths_of_unmatchable_reprs_of_different_sizes_with_extend_2(
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([("Var1", ...), "c", "d", "e"]),
-                output=TensorType(["a", "b", ("Var1", ...)]),
+                input=IOKey(
+                    shape=[("Var1", ...), "c", "d", "e"], type=GenericTensorType
+                ),
+                output=IOKey(shape=["a", "b", ("Var1", ...)], type=GenericTensorType),
             )
 
     model = Model()
@@ -7509,8 +7544,8 @@ def test_node_count_4():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", ("Var1", ...)]),
-                output=TensorType([("Var1", ...), "b"]),
+                input=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+                output=IOKey(shape=[("Var1", ...), "b"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -7542,9 +7577,9 @@ def test_node_count_5():
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input1=TensorType(["a", ("Var1", ...)]),
-                input2=TensorType([("Var1", ...), "b"]),
-                output=TensorType(["a", ("Var1", ...)]),
+                input1=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
+                input2=IOKey(shape=[("Var1", ...), "b"], type=GenericTensorType),
+                output=IOKey(shape=["a", ("Var1", ...)], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -7762,8 +7797,8 @@ def test_node_count_16() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType([5, 5]),
-                output=TensorType([5, 5]),
+                input=IOKey(shape=[5, 5], type=GenericTensorType),
+                output=IOKey(shape=[5, 5], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -7792,8 +7827,8 @@ def test_node_count_18() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b"]),
-                output=TensorType(["a", "b"]),
+                input=IOKey(shape=["a", "b"], type=GenericTensorType),
+                output=IOKey(shape=["a", "b"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -7821,8 +7856,10 @@ def test_node_count_19() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", ("V1", ...), "b", "c"]),
-                output=TensorType(["c", ("V1", ...), "a", "b"]),
+                input=IOKey(shape=["a", ("V1", ...), "b", "c"], type=GenericTensorType),
+                output=IOKey(
+                    shape=["c", ("V1", ...), "a", "b"], type=GenericTensorType
+                ),
             )
 
         def __call__(  # type: ignore[override]
@@ -7857,8 +7894,8 @@ def test_node_count_20() -> None:
         def __init__(self) -> None:
             super().__init__(
                 formula_key="buffer",
-                input=TensorType(["a", "b", "c"]),
-                output=TensorType(["b", "c", "a"]),
+                input=IOKey(shape=["a", "b", "c"], type=GenericTensorType),
+                output=IOKey(shape=["b", "c", "a"], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]
@@ -7892,7 +7929,9 @@ def test_node_count_21() -> None:
 
         def __init__(self) -> None:
             super().__init__(
-                formula_key="buffer", input=TensorType([]), output=TensorType([])
+                formula_key="buffer",
+                input=IOKey(shape=[], type=GenericTensorType),
+                output=IOKey(shape=[], type=GenericTensorType),
             )
 
         def __call__(  # type: ignore[override]

--- a/tests/scripts/test_type_consistencies.py
+++ b/tests/scripts/test_type_consistencies.py
@@ -38,7 +38,6 @@ from mithril.models import (
     Multiply,
     PrimitiveModel,
     PrimitiveUnion,
-    Scalar,
     Shape,
     Sigmoid,
 )
@@ -51,9 +50,9 @@ class Model1(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="None",
-            input1=Scalar(tuple[int, ...]),
-            input2=Scalar(list[float]),
-            output=Scalar(tuple[tuple[int, ...]]),
+            input1=IOKey(type=tuple[int, ...]),
+            input2=IOKey(type=list[float]),
+            output=IOKey(type=tuple[tuple[int, ...]]),
         )
 
     def __call__(  # type: ignore[override]
@@ -70,10 +69,10 @@ class Model2(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="None",
-            input1=Scalar(int | float),
-            input2=Scalar(int | str),
-            input3=Scalar(str | float),
-            output=Scalar(tuple[int | float, int | float, int | float]),
+            input1=IOKey(type=int | float),
+            input2=IOKey(type=int | str),
+            input3=IOKey(type=str | float),
+            output=IOKey(type=tuple[int | float, int | float, int | float]),
         )
 
     def __call__(  # type: ignore[override]
@@ -96,19 +95,19 @@ class Model3(PrimitiveModel):
     def __init__(self) -> None:
         super().__init__(
             formula_key="None",
-            input1=Scalar(
-                tuple[tuple[int | float, ...], ...]
+            input1=IOKey(
+                type=tuple[tuple[int | float, ...], ...]
                 | list[int | float]
                 | tuple[int, int, int, int]
             ),
-            input2=Scalar(list[int] | tuple[int, ...] | tuple[tuple[int | float]]),
-            input3=Scalar(
-                list[tuple[int | tuple[float | int]]]
+            input2=IOKey(type=list[int] | tuple[int, ...] | tuple[tuple[int | float]]),
+            input3=IOKey(
+                type=list[tuple[int | tuple[float | int]]]
                 | int
                 | float
                 | tuple[int | float, ...]
             ),
-            output=Scalar(int | float | str | tuple[int, int]),
+            output=IOKey(type=int | float | str | tuple[int, int]),
         )
 
     def __call__(  # type: ignore[override]


### PR DESCRIPTION
## Description

Closes #65.

## What is Changed

- TensorType is removed
- IOKey is used for defining key information in initialization of all primitive models

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).