### PR TITLE
fix: prevent zero-probability events from being sampled in multinomial function in Jax-backend

### DIFF
--- a/mithril/backends/with_autograd/jax_backend/backend.py
+++ b/mithril/backends/with_autograd/jax_backend/backend.py
@@ -532,11 +532,11 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
 
             # For without replacement, use Gumbel-max trick
             # This is much faster than using choice
-            z = jax.random.gumbel(prng_key, shape=input.shape + (num_samples,))
+            z = jax.random.gumbel(prng_key, shape=probs.shape + (num_samples,))
             # Add log probabilities for Gumbel-max trick,
             z = z + logits[..., None]
             # Get top k indices
-            samples = jax.numpy.argsort(-z, axis=input.ndim - 1)[..., :num_samples, 0]
+            samples = jax.numpy.argsort(-z, axis=probs.ndim - 1)[..., :num_samples, 0]
 
         return samples
 

--- a/mithril/backends/with_autograd/jax_backend/backend.py
+++ b/mithril/backends/with_autograd/jax_backend/backend.py
@@ -515,9 +515,7 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
         prng_key = self._get_prng_key(key)
         probs = jnp.asarray(probs)
         probs = probs / jnp.sum(probs, axis=-1, keepdims=True)
-
-        # Mask zero probabilities to avoid log(0) without adding small constants
-        logits = jnp.where(probs > 0, jnp.log(probs), -jnp.inf)
+        logits = jnp.log(probs)
 
         if replacement:
             # Use categorical directly - much faster than choice

--- a/mithril/backends/with_autograd/jax_backend/backend.py
+++ b/mithril/backends/with_autograd/jax_backend/backend.py
@@ -513,7 +513,6 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
             replacement: whether to sample with replacement
         """
         prng_key = self._get_prng_key(key)
-        probs = jnp.asarray(probs)
         probs = probs / jnp.sum(probs, axis=-1, keepdims=True)
         logits = jnp.log(probs)
 
@@ -521,7 +520,7 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
             # Use categorical directly - much faster than choice
             samples = jax.random.categorical(
                 prng_key,
-                logits,  # avoid log(0)
+                logits,
                 shape=probs.shape[:-1] + (num_samples,),
             )
         else:

--- a/tests/scripts/test_backend_fns.py
+++ b/tests/scripts/test_backend_fns.py
@@ -2060,3 +2060,42 @@ class TestRandUniform:
         assert not backend.any(output < 0)
         assert not backend.any(output > 10)
         assert list(output.shape) == fn_args[2:]
+
+
+@pytest.mark.parametrize(
+    "backendcls, device, dtype", backends_with_device_dtype, ids=names
+)
+class TestMultinomial:
+    def test_multinomial_with_replacement(self, backendcls, device, dtype):
+        backend = backendcls(device=device, dtype=dtype)
+        fn = backend.multinomial
+        fn_args = [backend.array([0.1, 0.3, 0.6]), 5]
+
+        output = fn(*fn_args, replacement=True)
+
+        assert not backend.any(output < 0)
+        assert not backend.any(output >= len(fn_args[0]))
+        assert list(output.shape) == [fn_args[1]]
+
+    def test_multinomial_without_replacement(self, backendcls, device, dtype):
+        backend = backendcls(device=device, dtype=dtype)
+        fn = backend.multinomial
+        fn_args = [backend.array([0.2, 0.3, 0.5]), 3]
+
+        output = fn(*fn_args, replacement=False)
+
+        assert not backend.any(output < 0)
+        assert not backend.any(output >= len(fn_args[0]))
+        assert list(output.shape) == [fn_args[1]]
+
+    def test_multinomial_invalid_probabilities(self, backendcls, device, dtype):
+        backend = backendcls(device=device, dtype=dtype)
+        fn = backend.multinomial
+
+        array_size = 1000
+        fn_args = [backend.array([0.0] * 500 + [1.0] + [0.0] * (array_size - 501)), 100]  # Sample 100 times
+
+        output = fn(*fn_args, replacement=True)
+
+        assert list(output.shape) == [fn_args[1]]
+        assert backend.all(output == 500)

--- a/tests/scripts/test_backend_fns.py
+++ b/tests/scripts/test_backend_fns.py
@@ -2093,7 +2093,7 @@ class TestMultinomial:
         fn = backend.multinomial
 
         array_size = 1000
-        fn_args = [backend.array([0.0] * 500 + [1.0] + [0.0] * (array_size - 501)), 100]  # Sample 100 times
+        fn_args = [backend.array([0.0] * 500 + [1.0] + [0.0] * (array_size - 501)), 100]
 
         output = fn(*fn_args, replacement=True)
 


### PR DESCRIPTION
## Description

This PR fixes the issue #7 where zero-probability events could still be sampled due to the use of a small constant (1e-37) in the logits calculation. The fix replaces this constant with -inf to ensure such events are never selected and eliminate zero prob event.

## What is Changed

Include the changes introduced in this PR.

- Updated the multinomial implementation to handle zero-probability outcomes correctly.
- Replaced 1e-37 with -inf using jnp.where for stable log calculations.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).