### PR TITLE
bug: Fix C Backend Source Files Path Bug

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include mithril/backends/with_manualgrad/c_backend/src/libmithrilc.so
+include mithril/coress/c/libmithrilc.so
 recursive-include mithril/backends/with_manualgrad/c_backend/src *

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,8 @@ class CustomBuildExt(build_ext):
         script_path = os.path.join(
             os.path.dirname(__file__),
             "mithril",
-            "backends",
-            "with_manualgrad",
-            "c_backend",
-            "src",
+            "cores",
+            "c",
             "compile.sh",
         )
         subprocess.check_call([shell, script_path])


### PR DESCRIPTION
## Description

Closes #203.


## What is Changed
- In the setup.py, the path of the source files is corrected.
- In Manifest.in, the path of the '.so' file is corrected.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).