### PR TITLE
feat: Add set APIs to Connection

### DIFF
--- a/mithril/framework/common.py
+++ b/mithril/framework/common.py
@@ -3290,14 +3290,14 @@ def create_shape_map(
 
 def create_shape_repr(
     shp_list: ShapeTemplateType,
-    solver: ConstraintSolver,
+    solver: ConstraintSolver | None = None,
     used_keys: UsedKeysType | None = None,
 ) -> ShapeRepr:
     if used_keys is None:
         _used_keys: UsedKeysType = {}
     else:
         _used_keys = used_keys
-    if shp_list == []:
+    if solver is not None and shp_list == []:
         assert solver.empty_node is not None
         return next(iter(solver.empty_node.reprs))
 
@@ -3320,7 +3320,9 @@ def create_shape_repr(
             if symbol not in _used_keys:
                 match symbol:
                     case int() if not isinstance(symbol, bool):
-                        if (_uni := solver.symbol_store.get(symbol)) is not None:
+                        if solver is None:
+                            symbol_obj = Uniadic(symbol)
+                        elif (_uni := solver.symbol_store.get(symbol)) is not None:
                             symbol_obj = _uni
                         else:
                             symbol_obj = solver.symbol_store[symbol] = Uniadic(symbol)

--- a/mithril/framework/logical/base.py
+++ b/mithril/framework/logical/base.py
@@ -197,6 +197,7 @@ class ConnectionData:
             m = self.model._get_outermost_parent()
             m.set_shapes({self: value})
         else:
+            self.metadata.set_type(Tensor[int | float | bool])
             assert self.metadata.shape is not None
             repr = create_shape_repr(value)
             self.metadata.shape.merge(repr.node)

--- a/tests/scripts/test_differentiablity.py
+++ b/tests/scripts/test_differentiablity.py
@@ -314,3 +314,30 @@ def test_diff_inference_add():
     model.set_types(left=Tensor)
 
     assert not model.left.metadata.differentiable  # type: ignore
+
+
+def test_diff_inference_add_connection():
+    model = Model()
+    model += (add := Add())("left", "right", "output")
+
+    assert not model.left.metadata.differentiable  # type: ignore
+    assert not model.right.metadata.differentiable  # type: ignore
+    assert not model.output.metadata.differentiable  # type: ignore
+
+    add.left.set_differentiability(False)
+
+    assert not model.left.metadata.differentiable  # type: ignore
+
+    model.set_types(left=Tensor)
+
+    assert not model.left.metadata.differentiable  # type: ignore
+
+
+def test_diff_inference_add_connection_without_model():
+    left = IOKey("left", type=Tensor)
+    assert left.metadata.differentiable is None
+    left.set_differentiability(False)
+    assert left.metadata.differentiable is False
+    model = Model()
+    model += Add()(left, "right", "output")
+    assert not model.left.metadata.differentiable  # type: ignore

--- a/tests/scripts/test_set_shapes.py
+++ b/tests/scripts/test_set_shapes.py
@@ -203,3 +203,58 @@ def test_set_shapes_8():
         "output": ["(V1, ...)"],
     }
     check_shapes_semantically(ref_shapes, model.shapes)
+
+
+def test_comparison_connection_set_shape():
+    model1 = Model()
+    model2 = Model()
+    model3 = Model()
+    model4 = Model()
+
+    model1 += (add1 := Add())(left="left", right="right", output=IOKey("output"))
+    model2 += model1(left="left", right="right", output=IOKey("output"))
+    model3 += model2(left="left", right="right", output=IOKey("output"))
+    model4 += model3(left="left", right="right", output=IOKey("output"))
+    model4 += (add2 := Add())(right="final_right", output=IOKey("final_output"))
+
+    add1.left.set_shapes([3, 4])
+    add1.right.set_shapes([3, 4])
+    add2.right.set_shapes([3, 4])
+
+    ref_shapes = {
+        "left": [3, 4],
+        "right": [3, 4],
+        "final_right": [3, 4],
+        "output": [3, 4],
+        "final_output": [3, 4],
+    }
+
+    check_shapes_semantically(ref_shapes, model4.shapes)
+
+
+def test_comparison_connection__without_model_set_shape():
+    model1 = Model()
+    model2 = Model()
+    model3 = Model()
+    model4 = Model()
+
+    model1 += Add()(left="left", right="right", output=IOKey("output"))
+    model2 += model1(left="left", right="right", output=IOKey("output"))
+    model3 += model2(left="left", right="right", output=IOKey("output"))
+
+    left = IOKey("left", shape=[3, 4])
+    right = IOKey("right", shape=[3, 4])
+    final_right = IOKey("final_right", shape=[3, 4])
+
+    model4 += model3(left=left, right=right, output=IOKey("output"))
+    model4 += Add()(right=final_right, output=IOKey("final_output"))
+
+    ref_shapes = {
+        "left": [3, 4],
+        "right": [3, 4],
+        "final_right": [3, 4],
+        "output": [3, 4],
+        "final_output": [3, 4],
+    }
+
+    check_shapes_semantically(ref_shapes, model4.shapes)

--- a/tests/scripts/test_set_shapes.py
+++ b/tests/scripts/test_set_shapes.py
@@ -242,9 +242,12 @@ def test_comparison_connection__without_model_set_shape():
     model2 += model1(left="left", right="right", output=IOKey("output"))
     model3 += model2(left="left", right="right", output=IOKey("output"))
 
-    left = IOKey("left", shape=[3, 4])
-    right = IOKey("right", shape=[3, 4])
-    final_right = IOKey("final_right", shape=[3, 4])
+    left = IOKey("left")
+    left.set_shapes([3, 4])
+    right = IOKey("right")
+    right.set_shapes([3, 4])
+    final_right = IOKey("final_right")
+    final_right.set_shapes([3, 4])
 
     model4 += model3(left=left, right=right, output=IOKey("output"))
     model4 += Add()(right=final_right, output=IOKey("final_output"))

--- a/tests/scripts/test_set_types.py
+++ b/tests/scripts/test_set_types.py
@@ -232,7 +232,7 @@ def test_set_types_connection():
     model = Model()
     buf_model = Buffer()
     model += buf_model(input="input", output=IOKey("output"))
-    buf_model.set_types(input=Tensor[int])
+    buf_model.input.set_type(Tensor[int])
 
     assert model.input.metadata.value_type is int  # type: ignore
     assert model.output.metadata.value_type is int  # type: ignore

--- a/tests/scripts/test_set_types.py
+++ b/tests/scripts/test_set_types.py
@@ -15,7 +15,7 @@
 import pytest
 
 from mithril.framework import IOKey, Tensor
-from mithril.models import Buffer, Indexer, Model, Sigmoid
+from mithril.models import Buffer, Connection, Indexer, Model, Sigmoid
 
 
 def test_set_types_1():
@@ -226,3 +226,26 @@ def test_types_iokey_3():
 
     assert buffer3_input.value_type is float
     assert buffer3_output.value_type is float
+
+
+def test_set_types_connection():
+    model = Model()
+    buf_model = Buffer()
+    model += buf_model(input="input", output=IOKey("output"))
+    buf_model.set_types(input=Tensor[int])
+
+    assert model.input.metadata.value_type is int  # type: ignore
+    assert model.output.metadata.value_type is int  # type: ignore
+
+
+def test_set_types_connection_without_model():
+    in_con = Connection()
+    in_con.set_type(Tensor[int])
+
+    model = Model()
+    buf_model = Buffer()
+    model += buf_model(input=in_con, output=IOKey("output"))
+    model.expose_keys(input=in_con)
+
+    assert model.input.metadata.value_type is int  # type: ignore
+    assert model.output.metadata.value_type is int  # type: ignore

--- a/tests/scripts/test_set_values.py
+++ b/tests/scripts/test_set_values.py
@@ -412,10 +412,10 @@ def test_comparison_connection_without_model_set_value_vs_model_set_value():
     model_1 = model
 
     bias = IOKey("bias")
+    bias.set_value(Tensor([1, 2.0]))
     model = Model()
     model += Linear(2)(input="input", weight="weight", bias=bias, output="output")
     model_2 = model
-    bias.set_value(Tensor([1, 2.0]))
 
     # Provide backend and data.
     backend = JaxBackend()

--- a/tests/scripts/test_set_values.py
+++ b/tests/scripts/test_set_values.py
@@ -377,3 +377,55 @@ def test_set_values_tensor_6():
     with pytest.raises(Exception) as err_info:
         model.set_values(output=Tensor([2, 3, 4]))
     assert str(err_info.value) == "Values of internal and output keys cannot be set."
+
+
+def test_comparison_connection_set_value_vs_model_set_value():
+    model = Model()
+    model += Linear(2)(input="input", weight="weight", bias="bias", output="output")
+    model.set_values(bias=Tensor([1, 2.0]))
+    model_1 = model
+
+    model = Model()
+    lin = Linear(2)
+    model += lin(input="input", weight="weight", bias="bias", output="output")
+    lin.bias.set_value(Tensor([1, 2.0]))
+    model_2 = model
+
+    # Provide backend and data.
+    backend = JaxBackend()
+    data = {"input": backend.array([[1.0, 2], [3, 4]])}
+    # Check equality.
+    compare_models(model_1, model_2, backend, data)
+
+    pm_1 = mithril.compile(model_1, backend=backend, constant_keys=data)
+    pm_2 = mithril.compile(model_2, backend=backend, constant_keys=data)
+    # Initialize parameters.
+    params_1, params_2 = init_params(backend, pm_1, pm_2)
+    # Check evaluations.
+    check_evaluations(backend, pm_1, pm_2, params_1, params_2)
+
+
+def test_comparison_connection_without_model_set_value_vs_model_set_value():
+    model = Model()
+    model += Linear(2)(input="input", weight="weight", bias="bias", output="output")
+    model.set_values(bias=Tensor([1, 2.0]))
+    model_1 = model
+
+    bias = IOKey("bias")
+    model = Model()
+    model += Linear(2)(input="input", weight="weight", bias=bias, output="output")
+    model_2 = model
+    bias.set_value(Tensor([1, 2.0]))
+
+    # Provide backend and data.
+    backend = JaxBackend()
+    data = {"input": backend.array([[1.0, 2], [3, 4]])}
+    # Check equality.
+    compare_models(model_1, model_2, backend, data)
+
+    pm_1 = mithril.compile(model_1, backend=backend, constant_keys=data)
+    pm_2 = mithril.compile(model_2, backend=backend, constant_keys=data)
+    # Initialize parameters.
+    params_1, params_2 = init_params(backend, pm_1, pm_2)
+    # Check evaluations.
+    check_evaluations(backend, pm_1, pm_2, params_1, params_2)


### PR DESCRIPTION
## Description

Add Model's all set APIs to Connection object too.

## What is Changed

- New set APIs added to Connection:
 `set_value`
 `set_differentiability`
 `set_type`
 `set_shape`
 `expose`

- Minor bug fixed in set_differentiability
- Corresponding tests added

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).