### PR TITLE
refactor: Refactor C AST to Use Visitor Pattern for Better Extensibility

### DIFF
--- a/mithril/framework/codegen/c_ast.py
+++ b/mithril/framework/codegen/c_ast.py
@@ -12,16 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
+from collections.abc import Sequence as TypedSequence
 from dataclasses import dataclass
+from typing import Any
+
+
+class NodeVisitor:
+    """Base NodeVisitor class for traversing the AST.
+
+    This implementation follows the Visitor pattern, allowing operations on
+    AST nodes to be defined separately from their structure.
+    """
+
+    def visit(self, node: "AST") -> Any:
+        """Visit a node and dispatch to the appropriate method."""
+        method_name = f"visit_{node.__class__.__name__.lower()}"
+        visitor = getattr(self, method_name)
+        return visitor(node)
 
 
 @dataclass
-class AST(ABC):
-    @abstractmethod
-    def to_str(self) -> str:
-        raise NotImplementedError("to_str is not implemented")
+class AST:
+    def accept(self, visitor: NodeVisitor) -> Any:
+        """Accept a visitor and return the result of the visit."""
+        return visitor.visit(self)
+
+    def children(self) -> list["AST"]:
+        """Return a list of all child nodes of this node.
+        By default, returns an empty list. Subclasses should override this method.
+        """
+        return []
 
 
 @dataclass
@@ -38,39 +59,33 @@ class Stmt(AST):
 class MakeStmt(Stmt):
     expr: Expr
 
-    def to_str(self) -> str:
-        return self.expr.to_str() + ";"
+    def children(self) -> list[AST]:
+        return [self.expr]
 
 
 @dataclass
 class Call(Expr):
     name: str
-    args: Sequence[str | Expr]
+    args: TypedSequence[str | Expr]
 
-    def to_str(self) -> str:
-        args_str = ", ".join(
-            [arg.to_str() if isinstance(arg, Expr) else arg for arg in self.args]
-        )
-        return f"{self.name}({args_str})"
+    def children(self) -> list[AST]:
+        return [arg for arg in self.args if isinstance(arg, Expr)]
 
 
 @dataclass
 class Constant(Expr):
     value: int | float | str
 
-    def to_str(self) -> str:
-        return str(self.value)
-
-    def __str__(self) -> str:
-        return self.to_str()
+    def children(self) -> list[AST]:
+        return []
 
 
 @dataclass
 class Variable(Expr):
     name: str
 
-    def to_str(self) -> str:
-        return self.name
+    def children(self) -> list[AST]:
+        return []
 
 
 @dataclass
@@ -78,11 +93,8 @@ class Assign(Stmt):
     target: Expr
     source: Expr | Stmt
 
-    def to_str(self) -> str:
-        result_str = f"{self.target.to_str()} = {self.source.to_str()}"
-        if not isinstance(self.source, Stmt):
-            result_str += ";"
-        return result_str
+    def children(self) -> list[AST]:
+        return [self.target, self.source]
 
 
 @dataclass
@@ -90,34 +102,24 @@ class Parameter:
     type: str | Expr
     name: str
 
-    def to_str(self) -> str:
-        type_str = self.type.to_str() if isinstance(self.type, Expr) else self.type
-        return f"{type_str} {self.name}"
-
 
 @dataclass
 class FunctionDef(Stmt):
     return_type: str
     name: str
     params: list[Parameter]
-    body: Sequence[Stmt | Expr]
+    body: TypedSequence[Stmt | Expr]
 
-    def to_str(self) -> str:
-        params_str = (
-            ("\n\t" + ",\n\t".join([param.to_str() for param in self.params]) + "\n")
-            if len(self.params) > 0
-            else ""
-        )
-        body_str = "\n    ".join([stmt.to_str() for stmt in self.body])
-        return f"\n{self.return_type} {self.name}({params_str})\n{{\n    {body_str}\n}}"
+    def children(self) -> list[AST]:
+        return list(self.body)
 
 
 @dataclass
 class Return(Stmt):
     value: Expr
 
-    def to_str(self) -> str:
-        return f"return {self.value.to_str()};"
+    def children(self) -> list[AST]:
+        return [self.value]
 
 
 @dataclass
@@ -125,11 +127,8 @@ class Include(AST):
     header: str
     system: bool = False  # True for system headers, False for user-defined headers
 
-    def to_str(self) -> str:
-        if self.system:
-            return f"#include <{self.header}>"
-        else:
-            return f'#include "{self.header}"'
+    def children(self) -> list[AST]:
+        return []
 
 
 @dataclass
@@ -137,16 +136,8 @@ class Comment(Stmt):
     text: str
     multiline: bool = False  # True for /* */ comments, False for // comments
 
-    def to_str(self) -> str:
-        if self.multiline:
-            # Format multiline comments with proper line breaks
-            lines = self.text.split("\n")
-            if len(lines) == 1:
-                return f"/* {self.text} */"
-            formatted_lines = [f" * {line}" for line in lines]
-            return "/*\n" + "\n".join(formatted_lines) + "\n */"
-        else:
-            return f"// {self.text}"
+    def children(self) -> list[AST]:
+        return []
 
 
 @dataclass
@@ -154,54 +145,36 @@ class StructField:
     type: str | Expr
     name: str
 
-    def to_str(self) -> str:
-        type_str = self.type.to_str() if isinstance(self.type, Expr) else self.type
-        return f"    {type_str} {self.name};"
-
 
 @dataclass
 class StructDef(Stmt):
     name: str
     fields: list[StructField]
 
-    def to_str(self) -> str:
-        fields_str = "\n".join(field.to_str() for field in self.fields)
-        return f"\nstruct {self.name} {{\n{fields_str}\n}};\n"
+    def children(self) -> list[AST]:
+        return []  # StructField is not derived from AST
 
 
 @dataclass
 class FILE(AST):
     includes: list[Include]
     globals: list[Stmt]
-    declarations: list[
-        FunctionDef
-    ]  # Union[FunctionDef, VariableDecl]]  # Add other top-level declarations as needed
+    declarations: list[FunctionDef]
 
-    def to_str(self) -> str:
-        includes_str = "\n".join(include.to_str() for include in self.includes)
-        globals_str = "\n".join(stmt.to_str() for stmt in self.globals)
-        declarations_str = "\n\n".join(decl.to_str() for decl in self.declarations)
-        return f"{includes_str}\n\n{globals_str}\n\n{declarations_str}"
+    def children(self) -> list[AST]:
+        return self.includes + self.globals + self.declarations  # type: ignore
 
 
 @dataclass
-class StructInit(Stmt):
+class StructInit(Expr):
     struct_name: str
     field_values: Mapping[str, Expr | str]
     static: bool = False
 
-    def to_str(self) -> str:
-        field_inits = [
-            f".{field} = {value.to_str() if isinstance(value, Expr) else value}"
-            for field, value in self.field_values.items()
+    def children(self) -> list[AST]:
+        return [
+            value for value in self.field_values.values() if isinstance(value, Expr)
         ]
-        fields_str = ", ".join(field_inits)
-
-        stmt = f"struct {self.struct_name} = {{ {fields_str} }};"
-        if self.static:
-            stmt = f"static {stmt}"
-
-        return stmt
 
 
 @dataclass
@@ -210,11 +183,13 @@ class StaticVariable(Stmt):
     name: str
     initial_value: Expr | None = None
 
-    def to_str(self) -> str:
-        type_str = self.type.to_str() if isinstance(self.type, Expr) else self.type
-        if self.initial_value is None:
-            return f"static {type_str} {self.name};"
-        return f"static {type_str} {self.name} = {self.initial_value.to_str()};"
+    def children(self) -> list[AST]:
+        result = []
+        if isinstance(self.type, Expr):
+            result.append(self.type)
+        if self.initial_value is not None:
+            result.append(self.initial_value)
+        return result  # type: ignore
 
 
 @dataclass
@@ -223,16 +198,11 @@ class If(Stmt):
     body: list[Stmt]
     else_body: list[Stmt] | None = None
 
-    def to_str(self) -> str:
-        body_str = "\n    ".join([stmt.to_str() for stmt in self.body])
-        if self.else_body is None:
-            return f"if ({self.condition.to_str()}) {{\n    {body_str}\n}}"
-        else:
-            else_str = "\n    ".join([stmt.to_str() for stmt in self.else_body])
-            return (
-                f"if ({self.condition.to_str()}) {{\n    {body_str}\n}} else "
-                f"{{\n    {else_str}\n}}"
-            )
+    def children(self) -> list[AST]:
+        result = [self.condition] + self.body
+        if self.else_body:
+            result.extend(self.else_body)
+        return result  # type: ignore
 
 
 @dataclass
@@ -240,8 +210,8 @@ class Arrow(Expr):
     target: Expr
     field: str
 
-    def to_str(self) -> str:
-        return f"{self.target.to_str()}->{self.field}"
+    def children(self) -> list[AST]:
+        return [self.target]
 
 
 @dataclass
@@ -249,16 +219,205 @@ class Dot(Expr):
     target: Variable
     field: str
 
-    def to_str(self) -> str:
-        return f"{self.target.to_str()}.{self.field}"
+    def children(self) -> list[AST]:
+        return [self.target]
 
 
 @dataclass
 class Pointer(Expr):
     target: str | Expr
 
-    def to_str(self) -> str:
+    def children(self) -> list[AST]:
+        return [self.target] if isinstance(self.target, Expr) else []
+
+
+@dataclass
+class BinaryOp(Expr):
+    """Binary operation (e.g., a > b, a + b)."""
+
+    op: str
+    left: Expr
+    right: Expr
+
+    def children(self) -> list[AST]:
+        return [self.left, self.right]
+
+
+class CStyleCodeGenerator(NodeVisitor):
+    """A visitor that generates C code from the AST."""
+
+    def __init__(self, indent_char: str = "    ", initial_indent: int = 0):
+        self.indent_char = indent_char  # Default to 4 spaces
+        self.indent_level = initial_indent
+
+    def indent(self) -> None:
+        """Increase the indentation level."""
+        self.indent_level += 1
+
+    def dedent(self) -> None:
+        """Decrease the indentation level."""
+        self.indent_level = max(0, self.indent_level - 1)
+
+    def get_indent(self) -> str:
+        """Get the current indentation string."""
+        return self.indent_char * self.indent_level
+
+    def format_block(self, statements: list[Stmt | Expr]) -> str:
+        """Format a block of statements with proper indentation."""
+        self.indent()
+        formatted = [f"{self.get_indent()}{self.visit(stmt)}" for stmt in statements]
+        self.dedent()
+        return "\n".join(formatted)
+
+    def visit_makestmt(self, node: MakeStmt) -> str:
+        return self.visit(node.expr) + ";"
+
+    def visit_call(self, node: Call) -> str:
+        args_str = ", ".join(
+            [
+                self.visit(arg) if isinstance(arg, Expr) else str(arg)
+                for arg in node.args
+            ]
+        )
+        return f"{node.name}({args_str})"
+
+    def visit_constant(self, node: Constant) -> str:
+        return str(node.value)
+
+    def visit_variable(self, node: Variable) -> str:
+        return node.name
+
+    def visit_assign(self, node: Assign) -> str:
+        result_str = f"{self.visit(node.target)} = {self.visit(node.source)}"
+        if not isinstance(node.source, Stmt):
+            result_str += ";"
+        return result_str
+
+    def visit_parameter(self, node: Parameter) -> str:
+        type_str = self.visit(node.type) if isinstance(node.type, Expr) else node.type
+        return f"{type_str} {node.name}"
+
+    def visit_functiondef(self, node: FunctionDef) -> str:
+        params_str = (
+            ("\n\t" + ",\n\t".join([self.visit(param) for param in node.params]) + "\n")  # type: ignore
+            if len(node.params) > 0
+            else ""
+        )
+
+        # Save current indent level for restoration after function body
+        old_indent = self.indent_level
+        self.indent_level = 0  # Reset for function body
+
+        body_formatted = self.format_block(node.body)  # type: ignore
+
+        # Restore previous indent level
+        self.indent_level = old_indent
+
+        return (
+            f"\n{node.return_type} {node.name}({params_str})\n{{\n{body_formatted}\n}}"
+        )
+
+    def visit_return(self, node: Return) -> str:
+        return f"return {self.visit(node.value)};"
+
+    def visit_include(self, node: Include) -> str:
+        if node.system:
+            return f"#include <{node.header}>"
+        else:
+            return f'#include "{node.header}"'
+
+    def visit_comment(self, node: Comment) -> str:
+        if node.multiline:
+            # Format multiline comments with proper line breaks
+            lines = node.text.split("\n")
+            if len(lines) == 1:
+                return f"/* {node.text} */"
+            formatted_lines = [f" * {line}" for line in lines]
+            return "/*\n" + "\n".join(formatted_lines) + "\n */"
+        else:
+            return f"// {node.text}"
+
+    def visit_structfield(self, node: StructField) -> str:
+        type_str = self.visit(node.type) if isinstance(node.type, Expr) else node.type
+        return f"{type_str} {node.name};"
+
+    def visit_structdef(self, node: StructDef) -> str:
+        # Save current indent level
+        old_indent = self.indent_level
+        self.indent_level = 0  # Reset for struct body
+
+        self.indent()
+        fields_str = "\n".join(
+            f"{self.get_indent()}{self.visit(field)}"  # type: ignore
+            for field in node.fields
+        )
+        self.dedent()
+
+        # Restore previous indent level
+        self.indent_level = old_indent
+
+        return f"\nstruct {node.name} {{\n{fields_str}\n}};\n"
+
+    def visit_file(self, node: FILE) -> str:
+        includes_str = "\n".join(self.visit(include) for include in node.includes)
+        globals_str = "\n".join(self.visit(stmt) for stmt in node.globals)
+        declarations_str = "\n\n".join(self.visit(decl) for decl in node.declarations)
+        return f"{includes_str}\n\n{globals_str}\n\n{declarations_str}"
+
+    def visit_structinit(self, node: StructInit) -> str:
+        field_inits = [
+            f".{field} = {self.visit(value) if isinstance(value, Expr) else value}"
+            for field, value in node.field_values.items()
+        ]
+        fields_str = ", ".join(field_inits)
+
+        stmt = f"struct {node.struct_name} = {{ {fields_str} }};"
+        if node.static:
+            stmt = f"static {stmt}"
+
+        return stmt
+
+    def visit_staticvariable(self, node: StaticVariable) -> str:
+        type_str = self.visit(node.type) if isinstance(node.type, Expr) else node.type
+        if node.initial_value is None:
+            return f"static {type_str} {node.name};"
+        return f"static {type_str} {node.name} = {self.visit(node.initial_value)};"
+
+    def visit_if(self, node: If) -> str:
+        condition = self.visit(node.condition)
+
+        # Format the body with proper indentation
+        body_formatted = self.format_block(node.body)  # type: ignore
+
+        if node.else_body is None:
+            return f"if ({condition}) {{\n{body_formatted}\n{self.get_indent()}}}"
+        else:
+            else_formatted = self.format_block(node.else_body)  # type: ignore
+            return (
+                f"if ({condition}) {{\n{body_formatted}\n{self.get_indent()}}}"
+                f" else {{\n{else_formatted}\n{self.get_indent()}}}"
+            )
+
+    def visit_arrow(self, node: Arrow) -> str:
+        return f"{self.visit(node.target)}->{node.field}"
+
+    def visit_dot(self, node: Dot) -> str:
+        return f"{self.visit(node.target)}.{node.field}"
+
+    def visit_pointer(self, node: Pointer) -> str:
         target_str = (
-            self.target.to_str() if isinstance(self.target, Expr) else self.target
+            self.visit(node.target) if isinstance(node.target, Expr) else node.target
         )
         return f"{target_str} *"
+
+    def visit_binaryop(self, node: BinaryOp) -> str:
+        """Visit a binary operation node."""
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        return f"{left} {node.op} {right}"
+
+
+def generate_code(ast_node: AST) -> str:
+    """Generate C code from an AST node using the visitor pattern."""
+    code_generator = CStyleCodeGenerator()
+    return ast_node.accept(code_generator)

--- a/mithril/framework/codegen/c_gen.py
+++ b/mithril/framework/codegen/c_gen.py
@@ -107,7 +107,9 @@ class CGen(CodeGen[PyArray]):
             )
             self.globals.append(grad_struct)
 
-        generated_code = c_ast.FILE(self.imports, self.globals, self.functions).to_str()  # type: ignore
+        generated_code = c_ast.FILE(self.imports, self.globals, self.functions).accept(  # type: ignore
+            c_ast.CStyleCodeGenerator()
+        )
 
         if file_path is None:
             with tempfile.NamedTemporaryFile(delete=False, suffix=".c") as tmp_file:

--- a/mithril/framework/codegen/c_gen.py
+++ b/mithril/framework/codegen/c_gen.py
@@ -290,14 +290,19 @@ class CGen(CodeGen[PyArray]):
             )
             inputs_struct_ptr = ctypes.pointer(inputs_struct)
 
-            _, output_struct = lib.evaluate(inputs_struct_ptr, output_gradients=True)
-            outputs = {}
+            output_struct = lib.evaluate_gradients(inputs_struct_ptr)
+
+            gradients = {}
             for grad_key in self.determined_struct_keys["eval_grad_output_keys"]:
                 key = grad_key.replace(self.BACKWARD_FN_SUFFIX, "")
                 array_ptr = getattr(output_struct, grad_key)
-                outputs[key] = PyArray(
+                gradients[key] = PyArray(
                     array_ptr.contents, shape=self._get_tensor_shape(key)
                 )
+
+            outputs = {}
+            for output_key in self.pm.output_keys:
+                outputs[output_key] = forward_pass[output_key]
 
             return outputs, gradients
 

--- a/tests/scripts/test_c_backend.py
+++ b/tests/scripts/test_c_backend.py
@@ -16,7 +16,6 @@ import os
 from copy import deepcopy
 
 import numpy as np
-import pytest
 
 from mithril import CBackend, GGMLBackend, NumpyBackend, compile
 from mithril.cores.c.array import PyArray
@@ -26,7 +25,6 @@ from mithril.models import Add, IOKey, Model, Multiply
 from ..utils import with_temp_file
 
 
-@pytest.mark.skip(reason="Change required on c backend, will be fixed in after merge!")
 def test_cbackend_1():
     model = Model()
 
@@ -112,7 +110,6 @@ def test_cbackend_1():
         assert np.allclose(ggml_backend.to_numpy(ggml_grads[key]), np_grads[key])
 
 
-@pytest.mark.skip(reason="Change required on c backend, will be fixed in after merge!")
 @with_temp_file(suffix=".c")
 def test_cbackend_2(file_path: str):
     model = Model()
@@ -183,7 +180,6 @@ def test_cbackend_2(file_path: str):
     os.remove(file_path.replace(".c", ".so"))
 
 
-@pytest.mark.skip(reason="Change required on c backend, will be fixed in after merge!")
 def test_cbackend_3():
     model = Model()
     add = Add()


### PR DESCRIPTION
## Description

Closes #260.

## What is Changed
- Replaced `to_str()` method with Visitor pattern for code generation
- Created `CStyleCodeGenerator` visitor for C code generation 
- Handled indentation for blocks like IF
- Fixed evaluate bug for C backends

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).