### PR TITLE
fix: GGML evaluate_gradient Raises Error

### DIFF
--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Make compile script executable
-        run: chmod +x ./mithril/backends/with_manualgrad/c_backend/src/compile.sh
       - name: Make compile scripts executable
         run: |
           chmod +x ./mithril/cores/c/raw_c/compile.sh

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -45,7 +47,6 @@ jobs:
           python3 -m pip install mypy
           python3 -m pip install pre-commit
           pre-commit run --all-files
-          python3 license_checker.py
       - name: Execute testcase unit tests
         run: pytest --cov --cov-report=xml -s tests/
       - name: Upload results to Codecov

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -21,9 +21,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Make compile script executable
         run: chmod +x ./mithril/backends/with_manualgrad/c_backend/src/compile.sh
+      - name: Make compile scripts executable
+        run: |
+          chmod +x ./mithril/cores/c/raw_c/compile.sh
+          chmod +x ./mithril/cores/c/ggml/compile.sh
+          chmod +x ./mithril/cores/c/ggml/build_ggml.sh
       - name: Compile C code
         run: |
-          pushd ./mithril/backends/with_manualgrad/c_backend/src
+          pushd ./mithril/cores/c/raw_c
+          ./compile.sh
+          popd
+          pushd ./mithril/cores/c/ggml
+          ./build_ggml.sh
           ./compile.sh
           popd
       - name: Install Python dependencies

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -4,78 +4,26 @@ on:
     branches: [ dev, main ]
   pull_request:
     branches: [ dev, main ]
-  workflow_dispatch: 
-  
 env:
   CI: true
 jobs:
-
-  pre_ci_checks:
-    runs-on: self-hosted
-    outputs:
-      cond_output: ${{ steps.contributors.outputs.cond }}
-    steps:
-    
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Check contributors
-        id: contributors
-        run: | 
-          EVENT_NAME=${{ github.event_name }}
-          if [ "${EVENT_NAME}" == "pull_request" ]; then
-            USERNAME=${{ github.actor }}
-            TRUSTED=$(yq -r '.trusted_contributors[].username' .github/contributors.yml | grep -Fxq "$USERNAME" && echo "true" || echo "false")
-            COND="$TRUSTED"
-          else
-            COND="true"
-          fi
-          echo "cond=$COND" >> $GITHUB_OUTPUT
-
-      - name: Clear cache if large
-        run: |
-          MAX_SIZE_GB=20
-
-          CONDA_PKGS_DIR=$(conda info --base)/pkgs
-          CURRENT_SIZE_GB=$(du -s "$CONDA_PKGS_DIR" | awk '{print $1 / 1024 / 1024}')
-
-          if (( $(echo "$CURRENT_SIZE_GB > $MAX_SIZE_GB" | bc -l) )); then
-              conda clean --all -y
-          fi
-  
-
   build:
-    runs-on: self-hosted
-    needs: pre_ci_checks
+    runs-on: macos-15-xlarge
     strategy:
       matrix:
         python-version: [3.12]
-    if: needs.pre_ci_checks.outputs.cond_output == 'true'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          submodules: 'recursive'
-
-      - name: Create Conda ennvironment with ${{ matrix.python-version }}
-        run: |
-          
-          conda create -n mithril-test-ci python=${{ matrix.python-version }} -y
-          source activate base
-          source activate mithril-test-ci
-
-      - name: Make compile scripts executable
-        run: |
-          chmod +x ./mithril/cores/c/raw_c/compile.sh
-          chmod +x ./mithril/cores/c/ggml/compile.sh
-          chmod +x ./mithril/cores/c/ggml/build_ggml.sh
+          python-version: ${{ matrix.python-version }}
+      - name: Make compile script executable
+        run: chmod +x ./mithril/backends/with_manualgrad/c_backend/src/compile.sh
       - name: Compile C code
         run: |
-          pushd ./mithril/cores/c/raw_c
-          ./compile.sh
-          popd
-          pushd ./mithril/cores/c/ggml
-          ./build_ggml.sh
+          pushd ./mithril/backends/with_manualgrad/c_backend/src
           ./compile.sh
           popd
       - name: Install Python dependencies
@@ -90,17 +38,13 @@ jobs:
           python3 -m pip install mypy
           python3 -m pip install pre-commit
           pre-commit run --all-files
+          python3 license_checker.py
       - name: Execute testcase unit tests
         run: pytest --cov --cov-report=xml -s tests/
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}    
-      - name: Deactivate and remove environment
-        run: |
-          source activate base
-          conda remove -n mithril-test-ci --all -y
-
+          token: ${{ secrets.CODECOV_TOKEN }}      
 
   on_failure:
     needs: build
@@ -116,17 +60,3 @@ jobs:
         run: |
           gh pr review ${{ github.event.pull_request.number }} -r -b "Tests are failed. Please review the PR."
           exit 1
-
-  deactivate_and_delete_environment:
-    needs: build
-    runs-on: self-hosted
-    env:
-      GH_TOKEN: ${{ github.token }}
-    if: ${{ failure() }}
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-      - name: remove conda environment
-        run: |
-          source activate base
-          conda remove -n mithril-test-ci --all -y

--- a/mithril/framework/codegen/ggml_gen.py
+++ b/mithril/framework/codegen/ggml_gen.py
@@ -132,6 +132,8 @@ class GGMLCodeGen(CGen):
         self, op: Operator, args: Sequence[str | int | float], context: str
     ) -> c_ast.Expr:
         formula_name = op.formula_key
+        if context == "eval_grad":
+            formula_name = f"{formula_name}{self.BACKWARD_FN_SUFFIX}"
 
         arg_exprs: list[c_ast.Expr] = []
         if formula_name in self.pre_processors:


### PR DESCRIPTION
## Description

Closes #263.

## What is Changed

-  When generating evaluate gradient function code, the bacward_suffix is used. 

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).