### PR TITLE
feat: Add Sharding Dimension Support to Parallel API

### DIFF
--- a/.github/workflows/ci-test-example.yml
+++ b/.github/workflows/ci-test-example.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.6 --index-url https://download.pytorch.org/whl/cpu
           pip install --upgrade "jax[cpu]"
           pip install -r requirements/dev.txt
           pip install tiktoken

--- a/.github/workflows/ci-test-example.yml
+++ b/.github/workflows/ci-test-example.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install torch==2.6 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cpu
           pip install --upgrade "jax[cpu]"
           pip install -r requirements/dev.txt
           pip install tiktoken

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           source activate mithril-test-ci
           python3 -m pip install --upgrade pip
-          pip install torch==2.4.1
+          pip install torch==2.6
           pip install --upgrade "jax[cpu]"
           pip install mlx==0.21.1
           pip install -r requirements/dev.txt

--- a/.github/workflows/ci-test-ubuntu.yaml
+++ b/.github/workflows/ci-test-ubuntu.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.6 --index-url https://download.pytorch.org/whl/cpu
           pip install --upgrade "jax[cpu]"
           pip install -r requirements/dev.txt
       - name: Run pre-commit

--- a/mithril/backends/with_autograd/torch_backend/parallel.py
+++ b/mithril/backends/with_autograd/torch_backend/parallel.py
@@ -211,7 +211,7 @@ class TorchParallel(Parallel[torch.Tensor]):
         base_mesh: DeviceMesh,
         device_mesh: tuple[int, ...] | tuple[tuple[int, int], ...] | None = None,
     ) -> STensor:
-        # TODO: The name `device_mesh` is suck, it should be renamed
+        # TODO: Rename device_mesh argument
 
         assert (
             type(tensor) is torch.Tensor
@@ -220,11 +220,9 @@ class TorchParallel(Parallel[torch.Tensor]):
             isinstance(device_mesh, tuple) or device_mesh is None
         ), "device_mesh must be a tuple or None."
 
-        n_device_mesh = utils.normalize_device_mesh(base_mesh.shape, device_mesh)
+        n_device_mesh = utils.normalize_device_mesh(base_mesh, device_mesh)
 
         if n_device_mesh is not None:
-            utils.check_device_mesh(base_mesh, n_device_mesh)
-
             # Check if the tensor shape is divisible by the device mesh dims
             for axis, shard_dim in n_device_mesh:
                 if tensor.shape[axis] % shard_dim != 0:
@@ -521,7 +519,7 @@ class TorchParallel(Parallel[torch.Tensor]):
                         Shard(dim) if placement == Instructions.SHARD else Replicate()
                         for placement, dim in args[1:]
                     ]
-                    print(placements)
+
                     dtensor = distribute_tensor(tensor, base_mesh, placements)
                     self.tensor_ref[self.tensor_id_counter] = dtensor
                     self.tensor_id_counter += 1

--- a/mithril/backends/with_autograd/torch_backend/utils.py
+++ b/mithril/backends/with_autograd/torch_backend/utils.py
@@ -479,21 +479,25 @@ def check_device_mesh(
 
 
 def normalize_device_mesh(
-    base_mesh_shape: tuple[int, ...],
+    base_mesh: DeviceMesh,
     device_mesh: tuple[int, ...] | tuple[tuple[int, int], ...] | None,
 ) -> tuple[tuple[int, int], ...] | None:
     # Normalizes device mesh to a tuple of tuples
     # Assume given (2, 3) as device mesh, it will be normalized to ((0, 2), (1, 3))
+    base_mesh_shape = base_mesh.shape
 
     n_device_mesh: tuple[tuple[int, int], ...] | None = ()
     if is_tuple_int(device_mesh):
         n_device_mesh = tuple((idx, dim) for idx, dim in enumerate(device_mesh))
     else:
-        n_device_mesh = device_mesh  #  type: ignore
+        n_device_mesh = device_mesh  # type: ignore
 
     if n_device_mesh is not None and len(n_device_mesh) < len(base_mesh_shape):
         for idx in range(len(base_mesh_shape) - len(n_device_mesh)):
             n_device_mesh += ((idx, 1),)
+
+    if n_device_mesh is not None:
+        check_device_mesh(base_mesh, n_device_mesh)
 
     return n_device_mesh
 

--- a/mithril/backends/with_autograd/torch_backend/utils.py
+++ b/mithril/backends/with_autograd/torch_backend/utils.py
@@ -32,6 +32,7 @@ from torch.distributed._tensor import DeviceMesh
 from .... import types
 from ....common import PythonGenConfig, find_dominant_type
 from ....cores.python.torch.utils import dtype_map
+from ....utils.type_utils import is_tuple_int
 from ...utils import DtypeSubTypes
 
 CODEGEN_CONFIG = PythonGenConfig(SPECIFY_DEVICE=True)
@@ -456,17 +457,45 @@ class SharedCyclicQueue:
             pass
 
 
-def check_device_mesh(base_mesh: DeviceMesh, device_mesh: tuple[int, ...]) -> None:
-    for idx, dim in enumerate(device_mesh):
-        if dim < 1:
+def check_device_mesh(
+    base_mesh: DeviceMesh, device_mesh: tuple[tuple[int, int], ...]
+) -> None:
+    if len(device_mesh) != len(base_mesh.shape):
+        raise ValueError(
+            "Device mesh must have the same number of dimensions as the base mesh."
+        )
+
+    for idx, (_, sharding) in enumerate(device_mesh):
+        if sharding < 1:
             raise ValueError(
-                f"Provided '{dim}' for device_mesh, but parallel execution requires"
-                f"each dim greater or equal to 1."
+                f"Provided '{sharding}' for device_mesh, but parallel execution"
+                f" requires each dim greater or equal to 1."
             )
-        if device_mesh[idx] != 1 and base_mesh.shape[idx] != device_mesh[idx]:
+
+        if sharding != 1 and base_mesh.shape[idx] != sharding:
             raise ValueError(
                 "Device mesh must be compatible with the model device mesh."
             )
+
+
+def normalize_device_mesh(
+    base_mesh_shape: tuple[int, ...],
+    device_mesh: tuple[int, ...] | tuple[tuple[int, int], ...] | None,
+) -> tuple[tuple[int, int], ...] | None:
+    # Normalizes device mesh to a tuple of tuples
+    # Assume given (2, 3) as device mesh, it will be normalized to ((0, 2), (1, 3))
+
+    n_device_mesh: tuple[tuple[int, int], ...] | None = ()
+    if is_tuple_int(device_mesh):
+        n_device_mesh = tuple((idx, dim) for idx, dim in enumerate(device_mesh))
+    else:
+        n_device_mesh = device_mesh  #  type: ignore
+
+    if n_device_mesh is not None and len(n_device_mesh) < len(base_mesh_shape):
+        for idx in range(len(base_mesh_shape) - len(n_device_mesh)):
+            n_device_mesh += ((idx, 1),)
+
+    return n_device_mesh
 
 
 def determine_dtype(

--- a/tests/scripts/test_parallel.py
+++ b/tests/scripts/test_parallel.py
@@ -24,6 +24,10 @@ import numpy as np
 import pytest
 import torch
 import torch.distributed
+from torch.distributed._tensor import (
+    Replicate,
+    Shard,
+)
 
 import mithril
 from mithril import compile
@@ -556,6 +560,43 @@ def test_torch_parallel_5():
         np.testing.assert_allclose(grad, parallel_grad, 1e-6, 1e-6)
 
 
+def test_row_wise_sharding():
+    backend = mithril.TorchBackend()
+    backend_parallel = create_parallel_backend(device_mesh=(1, 4))
+
+    input = backend.rand((32, 32))
+    weight = backend.rand((32, 32))
+
+    input_sharded = backend_parallel.array(input, device_mesh=((0, 1), (0, 4)))
+    row_wise_weight = backend_parallel.array(weight, device_mesh=((0, 1), (0, 4)))
+    assert row_wise_weight.placements == (Replicate(), Shard(0))
+    assert row_wise_weight._local_tensor.shape == (8, 32)
+
+    result = input @ weight
+    result_sharded = input_sharded @ row_wise_weight
+    assert result_sharded.placements == (Replicate(), Shard(0))
+    assert result_sharded._local_tensor.shape == (8, 32)
+
+    assert torch.allclose(result, result_sharded.full_tensor())
+
+
+def test_col_wise_sharding():
+    backend = mithril.TorchBackend()
+    backend_parallel = create_parallel_backend(device_mesh=(1, 4))
+
+    input = backend.rand((32, 32))
+    weight = backend.rand((32, 32))
+
+    input_sharded = backend_parallel.array(input, device_mesh=((0, 1), (1, 4)))
+    col_wise_weight = backend_parallel.array(weight, device_mesh=((0, 1), (1, 4)))
+    assert col_wise_weight.placements == (Replicate(), Shard(1))
+    assert col_wise_weight._local_tensor.shape == (32, 8)
+
+    result = input @ weight
+    result_sharded = input_sharded @ col_wise_weight
+    assert torch.allclose(result, result_sharded.full_tensor())
+
+
 def test_torch_static_parallel_1():
     # This test checks parallel execution with partial static inference.
     model = Model()
@@ -729,7 +770,7 @@ def test_torch_parallel_error_7():
 
     assert (
         str(e.value)
-        == "Device mesh must have the same or less dimensions than the tensor."
+        == "Device mesh must have the same number of dimensions as the base mesh."
     )
 
 


### PR DESCRIPTION
## Description

Closes #345.

## What is Changed

-  Extended the Parallel API to accept explicit sharding dimension specification using a tuple of (dim, shards) pairs (e.g., ((0, 2), (1, 4)))
-  Preserved backward compatibility with the original (dim, shards) format


## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).