### PR TITLE
refactor python codegen

### DIFF
--- a/mithril/backends/backend.py
+++ b/mithril/backends/backend.py
@@ -46,7 +46,7 @@ class Backend(ABC, Generic[DataType]):
         types.Dtype.float64,
     ]
     dtype_map: Any  # TODO: Type should be BiMAP
-    primitive_function_dict: dict[str, Callable[..., DataType | Any]]
+    op_function_dict: dict[str, Callable[..., DataType | Any]]
     registered_primitives: dict[str, Callable[..., DataType]]
     array_creation_funcs: list[str]
     primitive_fn_path: str

--- a/mithril/backends/with_autograd/jax_backend/backend.py
+++ b/mithril/backends/with_autograd/jax_backend/backend.py
@@ -73,7 +73,7 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
         os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = str(pre_allocate).lower()
 
         self.array_creation_funcs = ops.array_creation_funcs
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.dtype_map = core_utils.dtype_map
         self.prng_key = jax.random.PRNGKey(self.seed)
 

--- a/mithril/backends/with_autograd/mlx_backend/backend.py
+++ b/mithril/backends/with_autograd/mlx_backend/backend.py
@@ -54,7 +54,7 @@ class MlxBackend(Backend[mx.array]):
 
         self.dtype_map = core_utils.dtype_map
         self.array_creation_funcs = ops.array_creation_funcs
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.prng_key = mx.random.key(self.seed)
 
         for key, value in core_utils.dtype_map.items():

--- a/mithril/backends/with_autograd/torch_backend/backend.py
+++ b/mithril/backends/with_autograd/torch_backend/backend.py
@@ -70,7 +70,7 @@ class TorchBackend(ParallelBackend[torch.Tensor]):
             self._create_parallel(device_mesh)
 
         self.array_creation_funcs = ops.array_creation_funcs
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.dtype_map = core_utils.dtype_map
 
         self._generator = torch.Generator(device=self.device).manual_seed(0)

--- a/mithril/backends/with_manualgrad/c_backend/backend.py
+++ b/mithril/backends/with_manualgrad/c_backend/backend.py
@@ -39,7 +39,7 @@ class CBackend(Backend[PyArray]):
 
     def __init__(self) -> None:
         self._device = "cpu"
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.dtype_map = dtype_map
         self.registered_primitives = {}
         self.array_creation_funcs: list[str] = []

--- a/mithril/backends/with_manualgrad/ggml_backend/backend.py
+++ b/mithril/backends/with_manualgrad/ggml_backend/backend.py
@@ -41,7 +41,7 @@ class GGMLBackend(Backend[PyArray]):
 
     def __init__(self) -> None:
         self._device = "cpu"
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.dtype_map = dtype_map
         self.registered_primitives = {}
         self.array_creation_funcs: list[str] = []

--- a/mithril/backends/with_manualgrad/numpy_backend/backend.py
+++ b/mithril/backends/with_manualgrad/numpy_backend/backend.py
@@ -62,7 +62,7 @@ class NumpyBackend(Backend[np.ndarray[Any, Any]]):
 
         self.dtype_map = core_utils.dtype_map
         self.array_creation_funcs = ops.array_creation_funcs
-        self.primitive_function_dict = ops.primitive_func_dict
+        self.op_function_dict = ops.primitive_func_dict
         self.primitive_grad_function_dict = ops_grad.primitive_grad_func_dict
         self._seed_generator = np.random.default_rng(self.seed)
 

--- a/mithril/framework/codegen/py_style_codegen/torch_gen.py
+++ b/mithril/framework/codegen/py_style_codegen/torch_gen.py
@@ -41,6 +41,11 @@ class TorchCodeGen(PythonCodeGen[torch.Tensor]):
         output_key: str,
         formula_key: str,
     ) -> tuple[ast.Assign, set[str]]:
+        # Torch backend has to handle parallel tensor creation
+
+        if formula_key == "tensor":
+            self.add_partial_function(formula_key)
+
         generated_fn, used_keys = self.create_primitive_call(
             fn, l_input_keys, g_input_keys
         )

--- a/mithril/framework/physical/flat_graph.py
+++ b/mithril/framework/physical/flat_graph.py
@@ -648,8 +648,7 @@ class FlatGraph(GenericDataType[DataType]):
                 # TODO: Move this outside of while loop
                 # after CBackend is completely implemented.
                 fn_dict = (
-                    self.backend.primitive_function_dict
-                    | self.backend.registered_primitives
+                    self.backend.op_function_dict | self.backend.registered_primitives
                 )
 
                 static_value: DataType | MainValueType

--- a/mithril/framework/physical/model.py
+++ b/mithril/framework/physical/model.py
@@ -106,7 +106,7 @@ class PhysicalModel(GenericDataType[DataType]):
         self._output_keys: set[str] = set(model.conns.output_keys)
         flat_model = FlatModel(
             model,
-            backend.primitive_function_dict,
+            backend.op_function_dict,
             short_namings=use_short_namings,
         )
         self.external_key_mapping: dict[str, str] = flat_model.external_mapping

--- a/tests/scripts/test_flatmodel.py
+++ b/tests/scripts/test_flatmodel.py
@@ -31,7 +31,7 @@ from mithril.models import (
 )
 
 # NOTE: We need primitive_lut just for testing purposes here.
-primitive_lut = JaxBackend().primitive_function_dict
+primitive_lut = JaxBackend().op_function_dict
 
 
 def test_with_all_defined():

--- a/tests/scripts/test_immediate_extend.py
+++ b/tests/scripts/test_immediate_extend.py
@@ -652,7 +652,7 @@ def test_flat_model_key_naming_matching():
     assert model.conns.get_con_by_metadata(metadata) is not None  # type: ignore
     flat_model = FlatModel(
         model,
-        ml.JaxBackend().primitive_function_dict,
+        ml.JaxBackend().op_function_dict,
         short_namings=False,
     )
     assert flat_model.queued_models == {}

--- a/tests/scripts/test_primitive_directed.py
+++ b/tests/scripts/test_primitive_directed.py
@@ -51,7 +51,7 @@ def assert_forward(
             key: backend.array(value) if isinstance(value, np.ndarray) else value
             for key, value in kwargs.items()
         }
-        primitive_fn = backend.primitive_function_dict[formula_key]
+        primitive_fn = backend.op_function_dict[formula_key]
         result = primitive_fn(*_args, **_kwargs)
         if not isinstance(expected_result, np.ndarray | tuple | list):
             assert result == expected_result
@@ -73,7 +73,7 @@ def manul_vjp(
     args,
     kwargs,
 ):
-    fn = backend.primitive_function_dict[formula_key]
+    fn = backend.op_function_dict[formula_key]
     grad_fn = backend.primitive_grad_function_dict[f"{formula_key}_grad"]
     input_grads = []
     cache: dict[str, np.ndarray] = {}
@@ -118,7 +118,7 @@ def assert_backward(
                 else:
                     static_args[key] = value
 
-            primitive_fn = backend.primitive_function_dict[formula_key]
+            primitive_fn = backend.op_function_dict[formula_key]
             primitive_fn = partial(primitive_fn, **static_args, **_kwargs)
             _, grads, _ = backend.vjp(
                 primitive_fn, list(trainable_args.values()), cotangents=_out_grad


### PR DESCRIPTION
## Description

Closes #348 

## What is Changed
- Added detailed comments in `PythonCodeGen` to explain high‑level steps and helper methods  
- Renamed “primitive” terminology to “op” (e.g. `primitive_function_dict` → `op_function_dict`)  
- Extracted reusable helpers (e.g. `_check_deletable`, `get_op_details`, `add_registered_primitives`) to reduce duplication and improve structure  

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).