### PR TITLE
feat: Add ggml backend mode, remove context mode

### DIFF
--- a/mithril/framework/codegen/c_style_codegen/c_ast.py
+++ b/mithril/framework/codegen/c_style_codegen/c_ast.py
@@ -205,7 +205,7 @@ class BinaryOp(Expr):
 
 @dataclass
 class Cast(Expr):
-    target_type: str
+    target_type: str | Expr
     value: Expr
 
 
@@ -403,14 +403,20 @@ class CStyleCodeGenerator(NodeVisitor):
     def visit_addressof(self, node: AddressOf) -> str:
         return f"&{self.visit(node.target)}"
 
-    def visit_cast(self, node: Cast) -> str:
-        return f"({node.target_type}) {self.visit(node.value)}"
-
     def visit_binaryop(self, node: BinaryOp) -> str:
         """Visit a binary operation node."""
         left = self.visit(node.left)
         right = self.visit(node.right)
         return f"{left} {node.op} {right}"
+
+    def visit_cast(self, node: Cast) -> str:
+        type_str = (
+            self.visit(node.target_type)
+            if isinstance(node.target_type, Expr)
+            else node.target_type
+        )
+        value_str = self.visit(node.value)
+        return f"({type_str}) {value_str}"
 
     def _format_type(self, node: str | Expr) -> str:
         if isinstance(node, Expr):

--- a/mithril/framework/codegen/c_style_codegen/c_gen.py
+++ b/mithril/framework/codegen/c_style_codegen/c_gen.py
@@ -444,7 +444,7 @@ class CGen(CodeGen[PyArray]):
                         c_ast.Call(
                             "accumulate_grads",
                             [
-                                "eval_grad_static_ctx",
+                                "eval_backend_static_ctx",
                                 op_call,
                                 self.create_key_ref(input_key, context="eval_grad"),
                             ],
@@ -772,3 +772,6 @@ class CGen(CodeGen[PyArray]):
             return self.pm.shapes[key.replace(utils.BACKWARD_FN_SUFFIX, "")]  # type: ignore
         else:
             raise ValueError(f"Shape for key {key} not found")
+
+    def generate_dup_tensor(self, key: str, context: str) -> c_ast.Stmt:  # type: ignore
+        pass

--- a/mithril/framework/codegen/c_style_codegen/ggml_gen.py
+++ b/mithril/framework/codegen/c_style_codegen/ggml_gen.py
@@ -52,22 +52,40 @@ class GGMLCodeGen(CGen):
             c_ast.Constant("NULL"),
         )
 
+        backend_static_ctx = c_ast.StaticVariable(
+            c_ast.Pointer("g_context"),
+            "eval_backend_static_ctx",
+            c_ast.Constant("NULL"),
+        )
+
+        eval_allocr = c_ast.StaticVariable(
+            c_ast.Variable("ggml_gallocr_t"),
+            "eval_allocr",
+            c_ast.Constant("NULL"),
+        )
+
+        eval_buffer = c_ast.StaticVariable(
+            c_ast.Variable("ggml_backend_buffer_t"),
+            "eval_buffer",
+            c_ast.Constant("NULL"),
+        )
+
         eval_static_gf = c_ast.StaticVariable(
             c_ast.Pointer("struct ggml_cgraph"),
             "eval_static_gf",
             c_ast.Constant("NULL"),
         )
 
-        eval_grad_static_ctx = c_ast.StaticVariable(
-            c_ast.Pointer("g_context"),
-            "eval_grad_static_ctx",
+        eval_backend = c_ast.StaticVariable(
+            c_ast.Variable("ggml_backend_t"),
+            "eval_backend",
             c_ast.Constant("NULL"),
         )
 
-        eval_grad_static_gf = c_ast.StaticVariable(
-            c_ast.Pointer("struct ggml_cgraph"),
-            "eval_grad_static_gf",
-            c_ast.Constant("NULL"),
+        is_initialized = c_ast.StaticVariable(
+            c_ast.Variable("bool"),
+            "is_initialized",
+            c_ast.Constant("false"),
         )
 
         cleanup_fn = self.generate_cleanup_fn()
@@ -75,9 +93,12 @@ class GGMLCodeGen(CGen):
         self.globals.extend(
             [
                 eval_static_ctx,
-                eval_grad_static_ctx,
+                backend_static_ctx,
                 eval_static_gf,
-                eval_grad_static_gf,
+                eval_allocr,
+                eval_buffer,
+                eval_backend,
+                is_initialized,
                 cleanup_fn,
             ]
         )
@@ -97,17 +118,43 @@ class GGMLCodeGen(CGen):
         )
 
         if_check2 = c_ast.If(
-            c_ast.Variable("eval_grad_static_ctx != NULL"),
+            c_ast.Variable("eval_backend_static_ctx != NULL"),
             [
-                c_ast.MakeStmt(c_ast.Call("ggml_free", ["eval_grad_static_ctx"])),
+                c_ast.MakeStmt(c_ast.Call("ggml_free", ["eval_backend_static_ctx"])),
                 c_ast.Assign(
-                    c_ast.Variable("eval_grad_static_ctx"), c_ast.Constant("NULL")
+                    c_ast.Variable("eval_backend_static_ctx"), c_ast.Constant("NULL")
                 ),
             ],
         )
 
+        if_check3 = c_ast.If(
+            c_ast.Variable("eval_allocr != NULL"),
+            [
+                c_ast.MakeStmt(c_ast.Call("ggml_gallocr_free", ["eval_allocr"])),
+                c_ast.Assign(c_ast.Variable("eval_allocr"), c_ast.Constant("NULL")),
+            ],
+        )
+
+        if_check4 = c_ast.If(
+            c_ast.Variable("eval_buffer != NULL"),
+            [
+                c_ast.MakeStmt(c_ast.Call("ggml_backend_buffer_free", ["eval_buffer"])),
+                c_ast.Assign(c_ast.Variable("eval_buffer"), c_ast.Constant("NULL")),
+            ],
+        )
+
+        if_check5 = c_ast.If(
+            c_ast.Variable("eval_backend != NULL"),
+            [
+                c_ast.MakeStmt(c_ast.Call("ggml_backend_free", ["eval_backend"])),
+                c_ast.Assign(c_ast.Variable("eval_backend"), c_ast.Constant("NULL")),
+            ],
+        )
         fn_body.append(if_check1)
         fn_body.append(if_check2)
+        fn_body.append(if_check3)
+        fn_body.append(if_check4)
+        fn_body.append(if_check5)
 
         return c_ast.FunctionDef("void", "cleanup", [], fn_body)
 
@@ -136,9 +183,13 @@ class GGMLCodeGen(CGen):
 
     @override
     def call_op(
-        self, formula_key: str, input_vars: list[c_ast.Expr], context: str
+        self,
+        formula_key: str,
+        input_vars: list[c_ast.Expr],
+        context: str,
+        backend: bool = False,
     ) -> c_ast.Expr:
-        context_txt = "eval_static_ctx" if context == "eval" else "eval_grad_static_ctx"
+        context_txt = "eval_backend_static_ctx"
         return c_ast.Call(formula_key, [c_ast.Variable(context_txt), *input_vars])
 
     def update_compute_function(
@@ -154,7 +205,9 @@ class GGMLCodeGen(CGen):
         static_vars: list[c_ast.Stmt] = []
 
         fn_ref_name = "eval" if name == "evaluate" else "eval_grad"
-        ctx_name = f"{fn_ref_name}_static_ctx"
+        ctx_name = "eval_static_ctx"
+        backend_ctx_name = "eval_backend_static_ctx"
+        backend_name = "eval_backend"
 
         # Input tensors will be stored in static variables
         # We will update their data pointers in every call
@@ -170,11 +223,33 @@ class GGMLCodeGen(CGen):
                 )
             )
 
+        if fn_ref_name == "eval":
+            static_vars.append(
+                c_ast.StaticVariable("size_t", "buffer_size", c_ast.Constant("0"))
+            )
+
+            static_vars.append(
+                c_ast.StaticVariable(
+                    c_ast.Pointer("uint8_t"), "buffer", c_ast.Constant("NULL")
+                )
+            )
+
         pre_process = static_vars + pre_process
+
+        if fn_ref_name == "eval":
+            for output_key in reversed(list(self.pm.flat_graph.topological_order)):
+                operations.append(
+                    self.generate_dup_tensor(output_key, context=fn_ref_name)  # type: ignore
+                )
 
         # Initialization block
         init_block: ast_block_type = self.create_init_block(
-            operations, fn_ref_name, input_keys, ctx_name
+            operations,
+            fn_ref_name,
+            input_keys,
+            ctx_name,
+            backend_ctx_name,
+            backend_name,
         )
 
         # Update the data pointers of the input tensors
@@ -182,23 +257,13 @@ class GGMLCodeGen(CGen):
             input_keys, fn_ref_name
         )
 
-        compute_block = [
-            c_ast.Comment("Compute graph"),
-            c_ast.MakeStmt(
-                c_ast.Call(
-                    "ggml_graph_compute_with_ctx",
-                    [ctx_name, f"{fn_ref_name}_static_gf", c_ast.Constant(1)],
-                )
-            ),
-        ]
-
         # Compute graph
         compute_block = [
             c_ast.Comment("Compute graph"),
             c_ast.MakeStmt(
                 c_ast.Call(
-                    "ggml_graph_compute_with_ctx",
-                    [ctx_name, f"{fn_ref_name}_static_gf", c_ast.Constant(1)],
+                    "ggml_backend_graph_compute",
+                    [backend_name, "eval_static_gf"],
                 )
             ),
         ]
@@ -215,29 +280,82 @@ class GGMLCodeGen(CGen):
         fn_ref_name: str,
         input_keys: list[str],
         ctx_name: str,
+        backend_ctx_name: str,
+        backend_name: str,
     ) -> ast_block_type:
         init_block: ast_block_type = []
-
+        num_tensors = 2 * len(
+            set(self.struct_keys.eval_grad_input_keys)
+            | set(self.struct_keys.eval_input_keys)
+        )
         # Initialize context if NULL
         init_block.append(c_ast.Comment("One-time initialization"))  # type: ignore
-        init_block.append(
-            c_ast.StructInit(  # type: ignore
-                "ggml_init_params params",
-                {
-                    "mem_size": c_ast.Constant(
-                        1024 * 1024 * 512
-                    ),  # TODO: Calculate this
-                    "mem_buffer": c_ast.Constant("NULL"),
-                    "no_alloc": c_ast.Constant("false"),
-                },
+        if fn_ref_name == "eval":
+            init_block.append(
+                c_ast.StructInit(  # type: ignore
+                    "ggml_init_params params",
+                    {
+                        "mem_size": c_ast.BinaryOp(
+                            "*",
+                            c_ast.Call("ggml_tensor_overhead", [" "]),
+                            c_ast.Constant(num_tensors),
+                        ),
+                        "mem_buffer": c_ast.Constant("NULL"),
+                        "no_alloc": c_ast.Constant("true"),
+                    },
+                )
             )
-        )
-        init_block.append(
-            c_ast.Assign(  # type: ignore
-                c_ast.Variable(f"{fn_ref_name}_static_ctx"),
-                c_ast.Call("ggml_init", ["params"]),
+
+            init_block.append(
+                c_ast.Assign(
+                    c_ast.Constant("buffer_size"),
+                    c_ast.BinaryOp(
+                        "+",
+                        c_ast.Parameter(  # type: ignore
+                            c_ast.BinaryOp(
+                                "*",
+                                c_ast.Call("ggml_tensor_overhead", [""]),
+                                c_ast.Constant("GGML_DEFAULT_GRAPH_SIZE"),
+                            ),
+                            " ",
+                        ),
+                        c_ast.Call("ggml_graph_overhead", [""]),
+                    ),
+                )
             )
-        )
+            init_block.append(
+                c_ast.Assign(  # type: ignore
+                    c_ast.Constant("buffer"),
+                    c_ast.Cast(
+                        c_ast.Pointer("uint8_t"), c_ast.Call("malloc", ["buffer_size"])
+                    ),
+                )
+            )
+
+            init_block.append(
+                c_ast.StructInit(  # type: ignore
+                    "ggml_init_params backend_params",
+                    {
+                        "mem_size": c_ast.Constant("buffer_size"),
+                        "mem_buffer": c_ast.Constant("buffer"),
+                        "no_alloc": c_ast.Constant("true"),
+                    },
+                )
+            )
+
+            init_block.append(
+                c_ast.Assign(  # type: ignore
+                    c_ast.Variable(f"{ctx_name}"),
+                    c_ast.Call("ggml_init", ["params"]),
+                )
+            )
+
+            init_block.append(
+                c_ast.Assign(  # type: ignore
+                    c_ast.Variable(f"{backend_ctx_name}"),
+                    c_ast.Call("ggml_init", ["backend_params"]),
+                )
+            )
 
         # Create tensors
         init_block.append(c_ast.Comment("Create tensors only once"))  # type: ignore
@@ -280,16 +398,58 @@ class GGMLCodeGen(CGen):
                     )
                 )
 
-        # Create and build graph
+        if fn_ref_name == "eval":
+            # Create backend
+            init_block.extend(
+                [
+                    c_ast.Comment("Create backend object only once"),  # type: ignore
+                    c_ast.Assign(  # type: ignore
+                        c_ast.Variable(f"{backend_name}"),
+                        c_ast.Call("ggml_backend_cpu_init", ""),
+                    ),
+                ]
+            )
         init_block.extend(
             [
-                c_ast.Comment("Create graph object only once"),  # type: ignore
+                c_ast.Comment("Create backend buffer and allocate tensors only once"),  # type: ignore
                 c_ast.Assign(  # type: ignore
-                    c_ast.Variable(f"{fn_ref_name}_static_gf"),
-                    c_ast.Call("ggml_new_graph", [ctx_name]),
+                    c_ast.Variable("eval_buffer"),
+                    c_ast.Call(
+                        "ggml_backend_alloc_ctx_tensors",
+                        [f"{ctx_name}", f"{backend_name}"],
+                    ),
                 ),
             ]
         )
+        # Create and build graph
+        init_block.extend(
+            [
+                c_ast.Comment("Create graph allocator only once"),  # type: ignore
+                c_ast.Assign(  # type: ignore
+                    c_ast.Variable("eval_allocr"),
+                    c_ast.Call(
+                        "ggml_gallocr_new",
+                        [
+                            c_ast.Call(
+                                "ggml_backend_get_default_buffer_type",
+                                [f"{backend_name}"],
+                            )
+                        ],
+                    ),
+                ),
+            ]
+        )
+        if fn_ref_name == "eval":
+            # Create and build graph
+            init_block.extend(
+                [
+                    c_ast.Comment("Create graph object only once"),  # type: ignore
+                    c_ast.Assign(  # type: ignore
+                        c_ast.Variable("eval_static_gf"),
+                        c_ast.Call("ggml_new_graph", [backend_ctx_name]),
+                    ),
+                ]
+            )
 
         # Add the original body operations
         init_block += operations  # type: ignore
@@ -300,6 +460,20 @@ class GGMLCodeGen(CGen):
             if fn_ref_name == "eval"
             else self.struct_keys.eval_grad_output_keys
         )
+        if fn_ref_name == "eval":
+            for out_key in self.pm.flat_graph.topological_order:
+                init_block.append(
+                    c_ast.MakeStmt(  # type: ignore
+                        c_ast.Call(
+                            "ggml_build_forward_expand",
+                            [
+                                "eval_static_gf",
+                                self.create_key_ref(out_key, context=fn_ref_name),
+                            ],
+                        )
+                    )
+                )
+
         for out_key in output_keys:
             # If key is statically inferred, skip marking
             if out_key in input_keys:
@@ -310,18 +484,36 @@ class GGMLCodeGen(CGen):
                     c_ast.Call(
                         "ggml_build_forward_expand",
                         [
-                            f"{fn_ref_name}_static_gf",
+                            "eval_static_gf",
                             self.create_key_ref(out_key, context=fn_ref_name),
                         ],
                     )
                 )
             )
-
+        init_block.append(
+            c_ast.MakeStmt(  # type: ignore
+                c_ast.Call(
+                    "ggml_gallocr_alloc_graph",
+                    ["eval_allocr", "eval_static_gf"],
+                )
+            )
+        )
+        if fn_ref_name == "eval_grad":
+            init_block.append(
+                c_ast.MakeStmt(  # type: ignore
+                    c_ast.Assign(  # type: ignore
+                        c_ast.Variable("is_initialized"),
+                        c_ast.Constant("true"),
+                    )
+                )
+            )
         init_block.append(c_ast.MakeStmt(c_ast.Call("atexit", ["cleanup"])))  # type: ignore
 
         # Wrap initialization in if check
-        if_init = [c_ast.If(c_ast.Variable(f"{ctx_name} == NULL"), init_block)]  # type: ignore
-
+        if fn_ref_name == "eval":
+            if_init = [c_ast.If(c_ast.Variable(f"{ctx_name} == NULL"), init_block)]  # type: ignore
+        else:
+            if_init = [c_ast.If(c_ast.Variable("!is_initialized"), init_block)]  # type: ignore
         return if_init  # type: ignore
 
     @override
@@ -372,6 +564,15 @@ class GGMLCodeGen(CGen):
 
         return op, [*args[:-1], *shape], []
 
+    @override
+    def generate_dup_tensor(self, key: str, context: str) -> c_ast.Stmt:
+        input_vars: list[c_ast.Expr] = [
+            self.create_key_ref(key, context=context, load=False),
+        ]
+        op_call = self.call_op("ggml_dup", input_vars, context, True)
+        op_ast = self.assign_primitive_output(key, op_call, context=context)
+        return op_ast
+
     def _generate_update_tensor_pointers(
         self, input_keys: list[str], context: str
     ) -> ast_block_type:
@@ -403,12 +604,30 @@ class GGMLCodeGen(CGen):
                         c_ast.Arrow(c_ast.Arrow(c_ast.Variable("inputs"), key), "data"),
                     )
                 )
+                update_ptr_block.append(
+                    c_ast.Assign(  # type: ignore
+                        c_ast.Arrow(
+                            self.create_key_ref(key, context=context), "buffer"
+                        ),
+                        c_ast.Arrow(
+                            c_ast.Arrow(c_ast.Variable("inputs"), key), "buffer"
+                        ),
+                    )
+                )
             # For regular tensors, just update the data pointer
             else:
                 update_ptr_block.append(
                     c_ast.Assign(  # type: ignore
                         c_ast.Arrow(c_ast.Variable(f"{key}"), "data"),
                         c_ast.Arrow(c_ast.Arrow(c_ast.Variable("inputs"), key), "data"),
+                    )
+                )
+                update_ptr_block.append(
+                    c_ast.Assign(  # type: ignore
+                        c_ast.Arrow(c_ast.Variable(f"{key}"), "buffer"),
+                        c_ast.Arrow(
+                            c_ast.Arrow(c_ast.Variable("inputs"), key), "buffer"
+                        ),
                     )
                 )
 


### PR DESCRIPTION
## Description

Closes #364 

## What is Changed

- Remove context execution mode entirely.
- Introduce backend execution mode for all evaluations.
- Context, backend, and buffer will become global variables. They will be initialized once at the start of evaluate(). They will be reused inside both evaluate() and evaluate_gradients().

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).