### PR TITLE
fix: Fixed backtick quoting removal bug when GitHub automation edits an Issue

### DIFF
--- a/.github/scripts/cc_issue.py
+++ b/.github/scripts/cc_issue.py
@@ -49,5 +49,6 @@ if related_users := label_user_mapping.get(label):
     new_line = "CC: " + "".join(f"@{user}, " for user in all_users)[:-2]
     lines[-1] = new_line
     new_body = "".join(f"{line}\n" for line in lines)[:-1]
+    new_body.replace("`", "\\`")  # escape backticks
     command = f"gh issue edit {number} --body '{new_body}'"
     subprocess.run(command, shell=True)


### PR DESCRIPTION
## Description

Closes #372.

## What is Changed

- cc_issues.py is changed for fixing the issue

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).