### PR TITLE
fix: Minor Errors in Parallel Backends

### DIFF
--- a/mithril/backends/backend.py
+++ b/mithril/backends/backend.py
@@ -1475,11 +1475,11 @@ class ParallelBackend(Backend[DataType]):
         raise NotImplementedError("linspace is not implemented!")
 
     def register_callable[T: Any](
-        self, fn: Callable[..., T] | partial[T], fn_name: str, jit: bool
+        self, fn: Callable[..., T] | partial[T], jit: bool
     ) -> None:
         raise NotImplementedError()
 
-    def _run_callable(self, *primals: Any, fn_name: str) -> Any:
+    def _run_callable(self, *primals: Any, fn: Callable[..., Any]) -> Any:
         raise NotImplementedError()
 
     def _create_parallel(self, device_mesh: tuple[int, ...]) -> None:

--- a/mithril/backends/parallel.py
+++ b/mithril/backends/parallel.py
@@ -31,7 +31,7 @@ class Parallel(ABC, Generic[DataType]):
             )
 
     @abstractmethod
-    def run_callable(self, *primals: Any, fn_name: str) -> dict[str, Any]:
+    def run_callable(self, *primals: Any, fn: Callable[..., Any]) -> dict[str, Any]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/mithril/backends/with_autograd/jax_backend/backend.py
+++ b/mithril/backends/with_autograd/jax_backend/backend.py
@@ -153,23 +153,19 @@ class JaxBackend(ParallelBackend[jax.numpy.ndarray]):
         """
         return data.block_until_ready()
 
-    def register_callable(
-        self, fn: Callable[..., Any], fn_name: str, jit: bool = False
-    ) -> None:
+    def register_callable(self, fn: Callable[..., Any], jit: bool = False) -> None:
         assert (
             self._parallel_manager is not None
         ), "Parallel manager is not initialized!"
 
-        fn_name = str(id(self)) + fn_name
-        return self._parallel_manager.register_callable(fn, fn_name, jit)
+        return self._parallel_manager.register_callable(fn, jit)
 
-    def _run_callable(self, *primals: jax.Array, fn_name: str) -> Any:
+    def _run_callable(self, *primals: jax.Array, fn: Callable[..., Any]) -> Any:
         assert (
             self._parallel_manager is not None
         ), "Parallel manager is not initialized!"
 
-        fn_name = str(id(self)) + fn_name
-        return self._parallel_manager.run_callable(*primals, fn_name=fn_name)
+        return self._parallel_manager.run_callable(*primals, fn=fn)
 
     def _create_parallel(self, device_mesh: tuple[int, ...]) -> None:
         self._parallel_manager = JaxParallel(math.prod(device_mesh), self._device)

--- a/mithril/backends/with_autograd/torch_backend/backend.py
+++ b/mithril/backends/with_autograd/torch_backend/backend.py
@@ -150,7 +150,7 @@ class TorchBackend(ParallelBackend[torch.Tensor]):
             # print(f"Warning: empty_cache is not implemented for {self.device_type}")
 
     def register_callable(
-        self, fn: Callable[..., torch.Tensor], fn_name: str, jit: bool = False
+        self, fn: Callable[..., torch.Tensor], jit: bool = False
     ) -> None:
         """
         Register a callable function with the backend.
@@ -164,10 +164,7 @@ class TorchBackend(ParallelBackend[torch.Tensor]):
             self._parallel_manager is not None
         ), "Parallel manager is not initialized!"
 
-        fn_name = str(id(self)) + fn_name
-        self._parallel_manager.register_callable(
-            fn, fn_name, self.base_device_mesh, jit
-        )
+        self._parallel_manager.register_callable(fn, self.base_device_mesh, jit)
 
     def _create_parallel(self, device_mesh: tuple[int, ...]) -> None:
         assert isinstance(device_mesh, tuple), "Device mesh must be tuple or None!"
@@ -182,13 +179,12 @@ class TorchBackend(ParallelBackend[torch.Tensor]):
             self._raw_device_mesh
         )
 
-    def _run_callable(self, *primals: Any, fn_name: str) -> Any:
+    def _run_callable(self, *primals: Any, fn: Callable[..., Any]) -> Any:
         assert (
             self._parallel_manager is not None
         ), "Parallel manager is not initialized!"
 
-        fn_name = str(id(self)) + fn_name
-        return self._parallel_manager.run_callable(*primals, fn_name=fn_name)
+        return self._parallel_manager.run_callable(*primals, fn=fn)
 
     def __getstate__(self) -> object:
         state = self.__dict__.copy()

--- a/mithril/backends/with_autograd/torch_backend/parallel.py
+++ b/mithril/backends/with_autograd/torch_backend/parallel.py
@@ -560,6 +560,7 @@ class TorchParallel(Parallel[torch.Tensor]):
         self._send_instrcs(Instructions.EXIT)
         TorchParallel._instance = None
         TorchParallel.device_meshes = {}
+        TorchParallel.used_ports = set()
 
         for process in self.processes:
             process.join()

--- a/mithril/backends/with_autograd/torch_backend/parallel.py
+++ b/mithril/backends/with_autograd/torch_backend/parallel.py
@@ -139,7 +139,8 @@ class TorchParallel(Parallel[torch.Tensor]):
 
         return TorchParallel.device_meshes[mesh_shape]
 
-    def run_callable(self, *primals: Any, fn_name: str) -> Any:
+    def run_callable(self, *primals: Any, fn: Callable[..., Any]) -> Any:
+        fn_name = str(id(fn))
         primals_ref = apply_to_all_elems(
             lambda x: TensorRef(self.tensor_id_ref[id(x)])
             if isinstance(x, STensor)
@@ -165,12 +166,11 @@ class TorchParallel(Parallel[torch.Tensor]):
     def register_callable(
         self,
         fn: Callable[..., torch.Tensor],
-        fn_name: str,
         base_mesh: DeviceMesh,
         jit: bool = False,
     ) -> int:
         assert self.data_queues is not None, "Parallel manager is not initialized!"
-
+        fn_name = str(id(fn))
         if isinstance(fn, partial):
             caches = fn.keywords["cache"]
             cache_refs = apply_to_all_elems(
@@ -186,7 +186,7 @@ class TorchParallel(Parallel[torch.Tensor]):
             Instructions.REGISTER_CALLABLE,
             None,
             (int(jit),),
-            {"base_mesh": base_mesh.shape, "fn_name": fn_name},
+            {"base_mesh": base_mesh.shape, "fn_name": str(id(fn))},
             False,
         )
 

--- a/mithril/framework/codegen/py_style_codegen/python_gen.py
+++ b/mithril/framework/codegen/py_style_codegen/python_gen.py
@@ -210,12 +210,12 @@ class PythonCodeGen(CodeGen[Any], Generic[DataType]):
             isinstance(self.pm.backend, ParallelBackend)
             and self.pm.backend.n_devices > 1
         ):
-            self.pm.backend.register_callable(eval_fn, "eval_fn", jit)
+            self.pm.backend.register_callable(eval_fn, jit)
             if not self.pm.inference:
                 assert (
                     evaluate_all_fn is not None
                 ), "Evaluate all function is not defined!"
-                self.pm.backend.register_callable(evaluate_all_fn, "eval_all_fn", jit)
+                self.pm.backend.register_callable(evaluate_all_fn, jit)
 
         elif jit and not self.pm.backend.is_manualgrad:
             eval_fn = self.pm.backend.jit(eval_fn)

--- a/mithril/framework/physical/model.py
+++ b/mithril/framework/physical/model.py
@@ -1002,7 +1002,9 @@ class PhysicalModel(GenericDataType[DataType]):
                 isinstance(self.backend, ParallelBackend)
                 and self.backend.get_parallel_manager() is not None
             ):
-                outputs = self.backend._run_callable(params, data, fn_name="eval_fn")
+                outputs = self.backend._run_callable(
+                    params, data, fn=self._generated_eval_fn
+                )
             else:
                 if (
                     self.flat_graph.cached_data
@@ -1030,8 +1032,9 @@ class PhysicalModel(GenericDataType[DataType]):
                 isinstance(self.backend, ParallelBackend)
                 and self.backend.get_parallel_manager() is not None
             ):
+                assert self._generated_evaluate_all_fn is not None
                 outputs, gradients = self.backend._run_callable(
-                    params, data, _gradients, fn_name="eval_all_fn"
+                    params, data, _gradients, fn=self._generated_evaluate_all_fn
                 )
             else:
                 outputs, gradients = self._generated_evaluate_all_fn(


### PR DESCRIPTION
## Description

Minor Errors in Parallel Backends are fixed. Closes #378. 

## What is Changed

- Zero-rank tensors are correctly handled and sharded without errors.
- It is now possible to compile and run multiple models using the same parallel backend instance without encountering errors.

## Checklist:

- [x] Tests that cover the code added.
- [x] Corresponding changes documented.
- [x] All tests passed.
- [x] The code linted and styled (pre-commit run --all-files has passed).