### PR TITLE
feat: Model compilation logic updated to allow both `jit=True` and `file_path`

### DIFF
--- a/mithril/__init__.py
+++ b/mithril/__init__.py
@@ -162,13 +162,6 @@ def compile(
         jit=jit,
     )
 
-    if jit and file_path is not None:
-        # TODO Fix warning
-        raise RuntimeError(
-            "Cannot create file while 'jit' flag is true. To write model file set "
-            "'jit' flag to 'False'"
-        )
-
     # Pick code generator based on backend and generate code.
     CodeGen_Cls = code_gen_map[backend.__class__]
     codegen = CodeGen_Cls(pm)

--- a/tests/scripts/test_jittable.py
+++ b/tests/scripts/test_jittable.py
@@ -53,6 +53,7 @@ from mithril.models import (
     Unique,
 )
 
+from ..utils import with_temp_file
 from .test_utils import assert_results_equal
 
 to_tensor = partial(to_tensor, device="cpu")
@@ -176,6 +177,44 @@ def test_mymodel_numpy():
     inputs = compiled_model.randomize_params()
     result = compiled_model.evaluate(inputs)
     ref_output = {"output": np.array(8.0)}
+    assert_results_equal(result, ref_output)
+
+
+@with_temp_file(".py")
+def test_mymodel_jax_jit(file_path: str):
+    model = MyModel(dimension=1)
+    backend = JaxBackend()
+    static_inputs = {"input": backend.array(np_input)}
+    compiled_model = compile(
+        model=model,
+        backend=backend,
+        constant_keys=static_inputs,
+        jit=True,
+        file_path=file_path,
+        inference=True,
+    )
+    inputs = compiled_model.randomize_params()
+    result = compiled_model.evaluate(inputs)
+    ref_output = {"output": backend.array(8.0)}
+    assert_results_equal(result, ref_output)
+
+
+@with_temp_file(".py")
+def test_mymodel_torch_jit(file_path: str):
+    model = MyModel(dimension=1)
+    backend = JaxBackend()
+    static_inputs = {"input": backend.array(np_input)}
+    compiled_model = compile(
+        model=model,
+        backend=backend,
+        constant_keys=static_inputs,
+        jit=True,
+        file_path=file_path,
+        inference=True,
+    )
+    inputs = compiled_model.randomize_params()
+    result = compiled_model.evaluate(inputs)
+    ref_output = {"output": backend.array(8.0)}
     assert_results_equal(result, ref_output)
 
 

--- a/tests/scripts/test_jittable.py
+++ b/tests/scripts/test_jittable.py
@@ -202,7 +202,7 @@ def test_mymodel_jax_jit(file_path: str):
 @with_temp_file(".py")
 def test_mymodel_torch_jit(file_path: str):
     model = MyModel(dimension=1)
-    backend = JaxBackend()
+    backend = TorchBackend()
     static_inputs = {"input": backend.array(np_input)}
     compiled_model = compile(
         model=model,


### PR DESCRIPTION
## Description

Closes #387

## What is Changed
- The exception that prevents using jit=True alongside a file_path during model compilation is removed.
- Integration tests to verify that this feature works correctly for both the Torch and JAX backends are added.

## Checklist:

- [X] Tests that cover the code added.
- [X] Corresponding changes documented.
- [X] All tests passed.
- [X] The code linted and styled (pre-commit run --all-files has passed).